### PR TITLE
Fix hosted documentation and Fly edge readiness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,10 @@ deploy-edge:
 ifndef REGIONS
 	$(error REGIONS is required. Example: make deploy-edge REGIONS=nrt,lhr)
 endif
+	@grep -Eq '^[[:space:]]*edge[[:space:]]*=' fly.toml || \
+		{ echo 'edge process is disabled in fly.toml; follow docs/fly-ops.md before scaling' >&2; exit 1; }
+	@awk 'BEGIN { section = 0; found = 0 } /^\[http_service\]$$/ { section = 1; next } /^\[/ { section = 0 } section && /^[[:space:]]*processes[[:space:]]*=/ && /"edge"/ { found = 1 } END { exit !found }' fly.toml || \
+		{ echo 'edge is not attached to http_service.processes in fly.toml' >&2; exit 1; }
 	fly scale count edge=$(COUNT) --region $(REGIONS) --yes
 
 # Show all machines, regions, and process groups.
@@ -164,8 +168,9 @@ test-linux-ubuntu:
 test-integ: | web/dist
 	go test -count=1 -tags e2e -v -timeout 120s ./test/integ/...
 
-# Black-box rolling-upgrade and rollback gate against the last published
-# release. Requires the baseline tag to be available in the local clone.
+# Black-box rolling-upgrade and rollback gate against the configured historical
+# baseline (WT_COMPAT_BASELINE_REF, defaulted by the script). Requires that tag
+# to be available in the local clone.
 test-compat: | web/dist
 	scripts/test-backward-compat.sh
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,17 @@ ownership and audit attribution inside Wingthing, not a new operating-system
 security boundary. Optional grants and spawn bounds live in
 `~/.wingthing/clients.yaml`.
 
-To give the parent agent one qualified inventory across remote wings, log in on
-the client machine and use the direct connector instead:
+To give the parent agent one qualified inventory across remote wings, first log
+in and start Wingthing on every execution machine. Install and authenticate each
+provider CLI there as the OS user who will own its runs:
+
+```bash
+wt login
+wt start
+```
+
+Then log in on the parent-agent machine and add the direct connector (if it is
+also an execution wing, the commands above already satisfy its wing setup):
 
 ```bash
 wt login

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![ci](https://github.com/ehrlich-b/wingthing/actions/workflows/ci.yml/badge.svg)](https://github.com/ehrlich-b/wingthing/actions/workflows/ci.yml)
 
-Wingthing is a typed agent manager for durable agent runs and terminals. Give
-Codex, Claude, or another parent agent one control plane for starting and
-supervising work across all your machines. A person can inspect or take over the
-same terminal sessions from a terminal or browser.
+Wingthing is a local-first, agent-first manager for durable agent runs and
+terminals. Start by giving Codex, Claude, or another parent agent typed MCP
+control of agents on the same machine, using the code and provider login already
+there. Add remote machines or a browser only when the work requires them.
 
 The agents run where the code and hardware already live. Wingthing keeps their
 terminals alive, records semantic runs as durable tasks, applies sandbox policy,
@@ -13,7 +13,15 @@ and gives each caller an owner, actor, grant set, bound, and audit trail.
 
 https://github.com/user-attachments/assets/f1f04caf-4b07-4298-ba76-db5b226c38f2
 
-## Give an agent access to your agents
+Choose the smallest route that fits:
+
+1. An agent manages local agents through stdio MCP.
+2. A person starts a local sandboxed agent terminal.
+3. An agent reaches another machine through direct remote MCP.
+4. A person who needs a browser runs a self-hosted roost.
+5. An entitled account may optionally use the hosted `wingthing.ai` browser relay.
+
+## 1. Local agent control: stdio MCP
 
 Install Wingthing, then register its local MCP server with the agent that will
 coordinate the work:
@@ -43,10 +51,52 @@ Restart the client after registration. Ask it to call
 - exchange owner-scoped messages with another authenticated agent client; and
 - inspect the effective sandbox before launching anything.
 
-The local server uses the current OS user's authority. `--client` supplies
-ownership and audit attribution inside Wingthing, not a new operating-system
-security boundary. Optional grants and spawn bounds live in
-`~/.wingthing/clients.yaml`.
+The child agents use existing project directories and provider credentials on
+this computer. Wingthing does not clone the code or copy a provider login. The
+local server uses the current OS user's authority. `--client` supplies ownership
+and audit attribution inside Wingthing, not a new operating-system security
+boundary. Optional grants and spawn bounds live in `~/.wingthing/clients.yaml`.
+
+## 2. Local human terminal: sandboxed agent
+
+Use the same runtime directly when a person wants the terminal:
+
+```bash
+cd /path/to/existing/project
+wt egg claude --name research
+
+# Ctrl+B Q detaches without stopping the process
+wt attach research
+```
+
+The provider CLI must already be installed and authenticated for the current OS
+user. The project must already exist. No Wingthing account or wing daemon is
+required.
+
+The CLI also exposes persistent shells, arbitrary commands, and raw terminal
+operations:
+
+```bash
+wt terminal --name work                # persistent sandboxed shell
+wt terminal --name api -- npm run dev  # persistent arbitrary command
+
+# Ctrl+B Q detaches without stopping the process
+wt attach                              # list live sessions
+wt attach work                         # reattach by name or ID
+
+wt session ps --json
+wt session read api --json
+wt session send api r --enter --json
+wt session wait api --contains ready --json
+wt session rename api frontend --json
+wt session kill frontend --json
+```
+
+Terminal snapshots are ANSI state. Wingthing does not infer that an agent is
+done because a string appeared on screen. Use `agent_run`, `agent_wait`, and
+`agent_result` when the caller needs semantic task state.
+
+## 3. Different machines: direct remote MCP
 
 To give the parent agent one qualified inventory across remote wings, first log
 in and start Wingthing on every execution machine. Install and authenticate each
@@ -82,46 +132,10 @@ or disable native control under `direct_mcp` in `wing.yaml`. Organization member
 remain owner- and path-scoped, while owners/admins retain all configured paths. See
 the [security model](docs/security.md#native-direct-mcp-authority) for the policy shape.
 
-Hosted terminal relay is a separate transport decision. Existing configs remain
-compatible, while a wing can refuse relayed payloads regardless of account
-entitlement:
-
-```bash
-wt wing config set hosted_relay=deny
-wt stop && wt start
-```
-
-Direct discovery/signaling still works; terminal and general control payloads must go
-directly to the wing. The effective setting appears in wing capability metadata and
-denials are audited without commands, paths, or payload content.
-
-## Use the same runtime yourself
-
-```bash
-wt terminal --name work               # persistent sandboxed shell
-wt terminal --name api -- npm run dev  # persistent arbitrary command
-wt egg claude --name research         # persistent sandboxed agent
-
-# Ctrl+B Q detaches without stopping the process
-wt attach                              # list live sessions
-wt attach research                     # reattach by name or ID
-wt attach research --remote box        # reattach over ordinary SSH
-```
-
-The CLI exposes the raw terminal layer for scripts:
-
-```bash
-wt session ps --json
-wt session read api --json
-wt session send api r --enter --json
-wt session wait api --contains ready --json
-wt session rename api frontend --json
-wt session kill frontend --json
-```
-
-Terminal snapshots are ANSI state. Wingthing doesn't infer that an agent is
-done because a string appeared on screen. Use `agent_run`, `agent_wait`, and
-`agent_result` when the caller needs semantic task state.
+The direct connector is the route to choose when execution moves to another
+machine. It does not provide a browser display. Use `agent_run` for a semantic
+result, or `agent_start` when a person will later attach through the execution
+machine's CLI or SSH.
 
 ## The runtime model
 
@@ -156,11 +170,10 @@ person: CLI or browser ----------------/  (inspect or take over)
 detachment, but not an unplanned host restart. A run's record and result persist;
 an active headless run still depends on the supervising Wingthing process.
 
-`wingthing.ai` is the hosted identity, directory, key-exchange, and connection
-coordination service—roughly the control plane in a tailnet. It does not run the
-agents. New free accounts use direct remote MCP; Pro adds the encrypted hosted
-terminal and control relay. Local MCP, SSH, and self-hosted roosts do not require
-it.
+`wingthing.ai` can supply identity, an access-filtered directory, key exchange,
+and connection coordination for direct remote MCP. It does not run the agents or
+carry direct MCP payloads. Local MCP, local terminals, SSH, and self-hosted roosts
+do not require it.
 
 ### Shared control contract
 
@@ -212,23 +225,21 @@ outer VM as the security boundary. Wingthing still provides persistence and the
 control plane, reports `outer-boundary` to MCP clients, and records that mode in
 the audit log.
 
-## Browser and hosted service
+## 4. Browser visibility: self-hosted roost
 
-Browser access is optional:
+When a person needs a browser, run the browser portal locally first:
 
 ```bash
-wt login
-wt start
-open https://app.wingthing.ai
+wt roost start --https
+open https://localhost:8443
 ```
 
-The wing connects outbound, so it needs no public inbound port. Free accounts
-use the hosted site to register the wing and set up direct remote MCP; the
-hosted browser terminal is not part of that free path. Accounts with hosted
-relay access may use the application-encrypted browser terminal and control
-relay. The coordinator sees account, routing, and connection metadata, and the
-hosted browser still trusts JavaScript served by the service. Read
-[security.md](docs/security.md) before making a stronger claim.
+This self-hosted route needs no Wingthing account or hosted-relay entitlement.
+For a remote execution machine, keep the portal on localhost and carry its wing
+connection over SSH; follow the
+[self-hosted remote-browser recipe](patterns/personal-remote-wing/INSTRUCTIONS.md).
+For several people, configure OAuth, HTTPS, and an exact enrollment list as
+described below.
 
 A portal may have several wings. The native CLI can query the same authorized
 roster and probe each wing through the encrypted tunnel:
@@ -242,11 +253,11 @@ WINGTHING_DIR=~/.wingthing-lab wt login --roost https://lab.example.com
 WINGTHING_DIR=~/.wingthing-lab wt wings --roost https://lab.example.com --json
 ```
 
-The browser and native client select a wing by its stable `wing_id`. The hosted
-directory aggregates every wing registered to the account or its organizations.
-Peer-roost federation remains follow-up work.
+The browser and native client select a wing by its stable `wing_id`. A
+self-hosted gateway can list its embedded wing and other wings registered with
+that same gateway. Independent roosts do not federate their directories.
 
-## Shared roost
+### Self-hosted roost details
 
 Run a self-hosted portal, gateway, and embedded wing in one process:
 
@@ -313,6 +324,35 @@ This command shape follows the current
 [Codex MCP documentation](https://learn.chatgpt.com/docs/extend/mcp). Claude Code
 uses `claude mcp add --scope user --transport http lab
 https://lab.example.com/mcp`.
+
+## 5. Hosted browser relay: entitled and optional
+
+Use the hosted browser only when an account already has hosted-relay access and
+the selected wing's effective `hosted_relay` policy is `allow`:
+
+```bash
+wt login
+wt start
+open https://app.wingthing.ai
+```
+
+The wing connects outbound, so it needs no public inbound port. The hosted
+browser terminal is not part of the free direct-MCP path. In hosted-browser mode,
+the service relays application-encrypted terminal and control payloads, sees
+account and routing metadata, and supplies the browser JavaScript. Read
+[security.md](docs/security.md) for the exact boundary.
+
+Account entitlement and wing policy are separate. A wing can refuse hosted
+payload relay:
+
+```bash
+wt wing config set hosted_relay=deny
+wt stop && wt start
+```
+
+Direct discovery and signaling still work. The effective setting appears in wing
+capability metadata, and denials are audited without commands, paths, or payload
+content.
 
 ## Supported agents
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -18,6 +18,22 @@ Before launching, identify:
 Wingthing routes control. It does not create or synchronize workspaces, credentials,
 or memory across wings.
 
+## Choose the remote transport deliberately
+
+- Native remote MCP uses `wt mcp connect`. The connector machine must run
+  `wt login`; every execution machine must run `wt login` and `wt start`, have the
+  requested provider CLI installed and authenticated for the execution owner, and
+  already contain the requested workspace. This path is direct WebRTC and never
+  falls back to the hosted relay.
+- A hosted browser terminal requires both account-level hosted-relay access and an
+  execution wing whose effective `hosted_relay` policy is `allow` (the compatible
+  default). `hosted_relay: deny` overrides an otherwise entitled account until the
+  wing is restarted with the policy changed.
+- A self-hosted roost does not require a wingthing.ai hosted-relay entitlement. Its
+  operator controls enrollment and relay policy, and its HTTP MCP endpoint controls
+  that roost's embedded wing rather than joining independent roosts into one
+  inventory.
+
 ## Run safely
 
 1. Call `wingthing_capabilities` before relying on an operation or agent.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,9 +1,36 @@
 ---
 name: wingthing
-description: Use Wingthing's typed control plane to start and supervise coding agents in durable runs or terminals on local and remote wings.
+description: Use Wingthing local-first to start and supervise coding agents through typed MCP, then add remote machines or human-visible terminals only when needed.
 ---
 
 # Use Wingthing
+
+## Choose the smallest route
+
+Use this order. Do not start with a hosted service when a local route satisfies
+the task.
+
+1. **Local agent control:** register `wt mcp stdio --client NAME` with the parent
+   agent. It manages agents on this computer using existing workspaces and the
+   current OS user's existing provider logins. No Wingthing account or daemon is
+   required.
+2. **Local human terminal:** run `wt egg AGENT` from an existing project and
+   resume it with `wt attach`. This is the local sandboxed agent-terminal route.
+3. **Direct remote MCP:** use `wt mcp connect` when parent and child execution are
+   on different machines. The connector machine must run `wt login`; every execution machine must run `wt login` and `wt start`, already contain the
+   workspace, and have the provider CLI authenticated. Calls select an explicit
+   `wing_id`, travel over direct WebRTC, and never fall back to hosted relay.
+4. **Self-hosted browser:** when a person needs browser visibility, start with
+   `wt roost start --https`. A self-hosted roost does not require a wingthing.ai hosted-relay entitlement. For a remote wing, use the documented localhost
+   roost plus SSH tunnel; for a shared roost, require OAuth, HTTPS, and explicit
+   enrollment.
+5. **Optional hosted browser:** use `app.wingthing.ai` only when the account has
+   hosted-relay access and the selected wing's effective `hosted_relay` policy is
+   `allow`. This path requires both account-level hosted-relay access and wing
+   permission; `hosted_relay: deny` wins.
+
+An authenticated self-hosted roost's HTTP MCP endpoint controls that roost's
+embedded wing. It does not join independent roosts into one inventory.
 
 ## Place the work first
 
@@ -17,22 +44,6 @@ Before launching, identify:
 
 Wingthing routes control. It does not create or synchronize workspaces, credentials,
 or memory across wings.
-
-## Choose the remote transport deliberately
-
-- Native remote MCP uses `wt mcp connect`. The connector machine must run
-  `wt login`; every execution machine must run `wt login` and `wt start`, have the
-  requested provider CLI installed and authenticated for the execution owner, and
-  already contain the requested workspace. This path is direct WebRTC and never
-  falls back to the hosted relay.
-- A hosted browser terminal requires both account-level hosted-relay access and an
-  execution wing whose effective `hosted_relay` policy is `allow` (the compatible
-  default). `hosted_relay: deny` overrides an otherwise entitled account until the
-  wing is restarted with the policy changed.
-- A self-hosted roost does not require a wingthing.ai hosted-relay entitlement. Its
-  operator controls enrollment and relay policy, and its HTTP MCP endpoint controls
-  that roost's embedded wing rather than joining independent roosts into one
-  inventory.
 
 ## Run safely
 

--- a/cmd/wt/serve.go
+++ b/cmd/wt/serve.go
@@ -56,6 +56,51 @@ func saveLocalServeToken(configDir, token string) error {
 	})
 }
 
+type serveRuntime struct {
+	config       *config.Config
+	nodeRole     string
+	loginAddr    string
+	flyMachineID string
+	flyRegion    string
+	flyApp       string
+	autoRole     bool
+	autoLogin    bool
+}
+
+func loadServeRuntime(flyDataDir string) (*serveRuntime, error) {
+	runtime := &serveRuntime{
+		nodeRole:     os.Getenv("WT_NODE_ROLE"),
+		loginAddr:    os.Getenv("WT_LOGIN_ADDR"),
+		flyMachineID: os.Getenv("FLY_MACHINE_ID"),
+		flyRegion:    os.Getenv("FLY_REGION"),
+		flyApp:       os.Getenv("FLY_APP_NAME"),
+	}
+
+	// Detect an unmounted Fly edge before config.Load can create its state
+	// directory under /data and make that edge look like the volume-owning login
+	// process. Explicit WT_NODE_ROLE always wins.
+	if runtime.flyMachineID != "" && runtime.nodeRole == "" {
+		if info, err := os.Stat(flyDataDir); err == nil && info.IsDir() {
+			runtime.nodeRole = "login"
+		} else {
+			runtime.nodeRole = "edge"
+		}
+		runtime.autoRole = true
+	}
+
+	if runtime.nodeRole == "edge" && runtime.loginAddr == "" && runtime.flyApp != "" {
+		runtime.loginAddr = "http://login.process." + runtime.flyApp + ".internal:8080"
+		runtime.autoLogin = true
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, err
+	}
+	runtime.config = cfg
+	return runtime, nil
+}
+
 func serveCmd() *cobra.Command {
 	var addrFlag string
 	var devFlag bool
@@ -73,30 +118,20 @@ func serveCmd() *cobra.Command {
 					return err
 				}
 			}
-			cfg, err := config.Load()
+			runtime, err := loadServeRuntime("/data")
 			if err != nil {
 				return err
 			}
-
-			nodeRole := os.Getenv("WT_NODE_ROLE")
-			loginAddr := os.Getenv("WT_LOGIN_ADDR")
-			flyMachineID := os.Getenv("FLY_MACHINE_ID")
-			flyRegion := os.Getenv("FLY_REGION")
-			flyApp := os.Getenv("FLY_APP_NAME")
-
-			// Auto-detect node role on Fly: volume mounted at /data → login, else edge.
-			if flyMachineID != "" && nodeRole == "" {
-				if info, err := os.Stat("/data"); err == nil && info.IsDir() {
-					nodeRole = "login"
-				} else {
-					nodeRole = "edge"
-				}
+			cfg := runtime.config
+			nodeRole := runtime.nodeRole
+			loginAddr := runtime.loginAddr
+			flyMachineID := runtime.flyMachineID
+			flyRegion := runtime.flyRegion
+			flyApp := runtime.flyApp
+			if runtime.autoRole {
 				fmt.Printf("auto-detected node role: %s\n", nodeRole)
 			}
-
-			// Auto-derive login node address from Fly internal DNS.
-			if nodeRole == "edge" && loginAddr == "" && flyApp != "" {
-				loginAddr = "http://login.process." + flyApp + ".internal:8080"
+			if runtime.autoLogin {
 				fmt.Printf("auto-derived login addr: %s\n", loginAddr)
 			}
 

--- a/cmd/wt/serve_test.go
+++ b/cmd/wt/serve_test.go
@@ -1,12 +1,86 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/ehrlich-b/wingthing/internal/auth"
 	"github.com/ehrlich-b/wingthing/internal/relay"
 )
+
+func TestLoadServeRuntimeDetectsFlyRoleBeforeConfigCreatesDataDirectory(t *testing.T) {
+	t.Run("unmounted edge", func(t *testing.T) {
+		dataDir := filepath.Join(t.TempDir(), "data")
+		t.Setenv("WINGTHING_DIR", dataDir)
+		t.Setenv("FLY_MACHINE_ID", "edge-machine")
+		t.Setenv("FLY_REGION", "lhr")
+		t.Setenv("FLY_APP_NAME", "wingthing-test")
+		t.Setenv("WT_NODE_ROLE", "")
+		t.Setenv("WT_LOGIN_ADDR", "")
+
+		runtime, err := loadServeRuntime(dataDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if runtime.nodeRole != "edge" || !runtime.autoRole {
+			t.Fatalf("role = %q auto=%v, want auto-detected edge", runtime.nodeRole, runtime.autoRole)
+		}
+		if want := "http://login.process.wingthing-test.internal:8080"; runtime.loginAddr != want || !runtime.autoLogin {
+			t.Fatalf("login address = %q auto=%v, want %q", runtime.loginAddr, runtime.autoLogin, want)
+		}
+		if _, err := os.Stat(dataDir); err != nil {
+			t.Fatalf("config load did not create its state directory after role detection: %v", err)
+		}
+	})
+
+	t.Run("mounted login", func(t *testing.T) {
+		dataDir := filepath.Join(t.TempDir(), "data")
+		if err := os.Mkdir(dataDir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("WINGTHING_DIR", filepath.Join(dataDir, ".wingthing"))
+		t.Setenv("FLY_MACHINE_ID", "login-machine")
+		t.Setenv("FLY_APP_NAME", "wingthing-test")
+		t.Setenv("WT_NODE_ROLE", "")
+		t.Setenv("WT_LOGIN_ADDR", "")
+
+		runtime, err := loadServeRuntime(dataDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if runtime.nodeRole != "login" || !runtime.autoRole {
+			t.Fatalf("role = %q auto=%v, want auto-detected login", runtime.nodeRole, runtime.autoRole)
+		}
+		if runtime.loginAddr != "" || runtime.autoLogin {
+			t.Fatalf("login node derived an edge address: %q auto=%v", runtime.loginAddr, runtime.autoLogin)
+		}
+	})
+}
+
+func TestLoadServeRuntimePreservesExplicitNodeRoleAndLoginAddress(t *testing.T) {
+	dataDir := filepath.Join(t.TempDir(), "data")
+	if err := os.Mkdir(dataDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WINGTHING_DIR", filepath.Join(dataDir, ".wingthing"))
+	t.Setenv("FLY_MACHINE_ID", "edge-machine")
+	t.Setenv("FLY_APP_NAME", "wingthing-test")
+	t.Setenv("WT_NODE_ROLE", "edge")
+	t.Setenv("WT_LOGIN_ADDR", "http://login.internal:9090")
+
+	runtime, err := loadServeRuntime(dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.nodeRole != "edge" || runtime.autoRole {
+		t.Fatalf("role = %q auto=%v, want explicit edge", runtime.nodeRole, runtime.autoRole)
+	}
+	if runtime.loginAddr != "http://login.internal:9090" || runtime.autoLogin {
+		t.Fatalf("login address = %q auto=%v, want explicit address", runtime.loginAddr, runtime.autoLogin)
+	}
+}
 
 func TestSaveLocalServeTokenPreservesOrdinaryPortalLogin(t *testing.T) {
 	dir := t.TempDir()

--- a/docs/bryan-wingthing-direct-control-field-report.md
+++ b/docs/bryan-wingthing-direct-control-field-report.md
@@ -271,7 +271,8 @@ The direct manager is credible but not yet a polished default:
   separate directory, authorization, revocation, and conflict-resolution project.
 - Fresh authenticated enrollment and the remaining production account-cohort
   canaries still precede broad rollout. The physical two-machine canary and the
-  real N-1/candidate compatibility battery now pass.
+  configured historical-baseline/candidate compatibility battery now pass; the
+  pinned baseline is not an assertion about the immediately previous release.
 
 The two-machine canary also found three custom-roost UX/privacy defects. `wt start
 --roost` printed the public app URL, `wt wing status` validated the token against a

--- a/docs/direct-agent-manager-design.md
+++ b/docs/direct-agent-manager-design.md
@@ -164,8 +164,9 @@ The existing HTTP MCP endpoint remains available during migration, and the deplo
 The deterministic connector canary now crosses JSON-RPC stdio and two independent
 real WebRTC data channels, verifies qualified `home`/`office` routing, reconnects, and
 checks that the coordinator handled signaling only. The compatibility gate separately
-runs real N-1 and candidate binaries in both gateway/wing upgrade orders, starts a PTY
-through the old browser message shape, and proves the old binary can reopen candidate
-state. The direct-MCP canary remains an in-process network test; the release gate still
-requires the built `wt mcp connect` process and a real Codex/Claude client against two
-distinct hosts, including the WSL rig.
+runs the configured historical baseline and candidate binaries in both gateway/wing
+upgrade orders, starts a PTY through the old browser message shape, and proves the
+baseline binary can reopen candidate state. The pin is not automatically the
+immediately previous release. The direct-MCP canary remains an in-process network
+test; the release gate still requires the built `wt mcp connect` process and a real
+Codex/Claude client against two distinct hosts, including the WSL rig.

--- a/docs/egg-inheritance-design.md
+++ b/docs/egg-inheritance-design.md
@@ -101,7 +101,7 @@ host when configured.
 | Field | Merge behavior |
 |-------|---------------|
 | `fs` | Appended. Explicit `ro:` or `rw:` for a path **overrides** a `deny:` of the same path from a parent. |
-| `network` | Unioned. Child domains added to parent domains. `"*"` in any layer = full network. |
+| `network` | Unioned. Child domains added to parent domains. `"*"` in any layer selects the broadest platform policy: any CONNECT destination on Linux without a general route, while macOS emits no Seatbelt network deny. |
 | `env` | Unioned. Child vars added to parent vars. `"*"` in any layer = all env. |
 | `resources` | Scalar override — child value wins per-field (cpu, memory, max_fds). |
 | `shell` | Scalar override — child wins. |

--- a/docs/fly-ops.md
+++ b/docs/fly-ops.md
@@ -1,210 +1,207 @@
 # Fly Operations Guide
 
-Wingthing is a typed agent manager for durable agent runs and terminals. The Fly
-fleet hosts its public coordinator: identity, the authorized wing directory, key
-exchange, WebRTC signaling, the portal, and the optional encrypted relay. Agents
-still execute on a user's selected wing; neither Fly process group is a general
-agent host.
+Wingthing's Fly app is the public coordinator: identity, the authorized wing
+directory, key exchange, WebRTC signaling, the portal, and the optional encrypted
+relay. Agents execute only on a user's selected wing. A Fly machine is not an
+execution wing and does not receive a user's workspace or provider credentials.
+
+## Checked-in topology
+
+The active `fly.toml` is deliberately login-only:
+
+- `[processes].login` is enabled;
+- `[processes].edge` is commented out;
+- `[http_service].processes` contains only `"login"`;
+- the `wt_data` volume and the configured VM stanza apply only to `login`; and
+- the service keeps at least one login machine running.
+
+The active service attachment is therefore:
+
+```toml
+processes = ["login"]
+```
+
+That means an ordinary `fly deploy` of the checked-in file does not create or route
+traffic to an edge process. Verify the live machine count with `make status`; the
+configuration is the deployment target, not evidence of what an earlier manual
+scale command left running.
+
+The login process owns the SQLite volume at `/data` and serves the public HTTP and
+WebSocket surface. The binary also contains an optional edge role. An edge has no
+durable volume, skips the relay database, proxies login-owned HTTP/API work to the
+login process, and keeps synchronized session, wing, and entitlement caches.
+
+On Fly, an unset `WT_NODE_ROLE` is inferred before configuration loading: an
+already-mounted `/data` directory means `login`; its absence means `edge`. This
+ordering matters because configuration initialization itself may create state below
+`/data`. An edge with `FLY_APP_NAME` and no explicit `WT_LOGIN_ADDR` derives
+`http://login.process.<app>.internal:8080`. An explicit `WT_NODE_ROLE` or
+`WT_LOGIN_ADDR` takes precedence.
 
 ## Placement and durable state
 
 | Decision | Public Fly deployment |
 | --- | --- |
-| **Execution wing** | The access-filtered wing explicitly selected by `wing_id`. Login and edge machines coordinate connections but do not substitute themselves as execution targets. |
-| **Workspace** | An existing `cwd` on the selected wing. No Fly service clones or synchronizes user repositories or untracked files. |
-| **Display** | `agent_run` returns semantic state over direct MCP without a browser view. `agent_start` creates a persistent PTY; hosted browser/control relay is entitlement-gated, while CLI, SSH, and self-hosted displays remain compatible. |
-| **Provider credentials** | The execution owner's agent home on the selected wing. Fly secrets are only service credentials such as JWT, OAuth, billing, or internal-node keys—not Claude, Codex, SSH, or other user provider credentials. |
-| **Durable memory** | The login volume stores gateway account, organization, auth, entitlement, and routing records. Each wing remains authoritative for its task database, eggs, optional Wingthing memory, provider history, and workspaces. Edge machines are stateless. |
+| **Execution wing** | The access-filtered wing explicitly selected by `wing_id`. The coordinator never substitutes a Fly process as the execution target. |
+| **Workspace** | An existing `cwd` on the selected wing. The service does not clone or synchronize repositories or untracked files. |
+| **Display** | `agent_run` returns semantic state over direct MCP. `agent_start` creates a persistent PTY; hosted browser/control relay is entitlement-gated, while CLI, SSH, and self-hosted displays remain separate paths. |
+| **Provider credentials** | The execution owner's agent home on the selected wing. Fly secrets are service credentials, not Claude, Codex, SSH, or other user provider credentials. |
+| **Durable memory** | The login volume stores gateway account, organization, auth, entitlement, and routing records. Each wing remains authoritative for its task database, sessions, provider history, optional Wingthing memory, and workspaces. |
 
 The public `direct-free` relay policy changes transport entitlement, not ownership
-or organization authorization. Existing personal and organization directories,
-roles, configured path scopes, grants, and bounds continue to apply at the wing.
+or organization authorization. Wing-side roles, paths, grants, and bounds still
+apply.
 
-## Architecture
+## Internal-node trust
 
-Two process groups, one image:
-
-- **login** — has the SQLite volume at `/data`. Handles auth, API, social pages, WebSocket relay. There is exactly one.
-- **edge** — stateless. Handles WebSocket relay only. Proxies API/auth to login. There can be zero or many.
-
-Role is auto-detected: if `/data` exists (volume mounted), it's login. Otherwise edge. No env vars to set per machine.
-
-Edge nodes discover the login node via Fly internal DNS: `login.process.wingthing.internal:8080`.
-The `/internal/*` API accepts an unauthenticated network caller only when its
-source is cluster-private and the receiving process is configured as a Fly app
-machine. That path trusts the Fly organization's 6PN boundary; it does not prove a
-cryptographic caller identity. Set the same separate `WT_INTERNAL_SECRET` on every
-Fly process if other applications in the Fly organization are not equally trusted.
-A standalone or non-Fly split deployment must set that secret. The JWT signing key
-is never accepted as an HTTP credential.
+The `/internal/*` API accepts a network caller without `WT_INTERNAL_SECRET` only
+when the receiving process is configured as a Fly app machine and the request
+arrives from a cluster-private address. That trusts the Fly organization's private
+network boundary; it is not cryptographic caller authentication. Set the same
+separate `WT_INTERNAL_SECRET` on every process if other applications in that Fly
+organization are not equally trusted. A split non-Fly deployment must set the
+secret and keep the node transport private and encrypted where it can cross an
+untrusted network. Do not reuse `WT_JWT_KEY` as the internal secret.
 
 ## One-time setup
 
-Generate an EC P-256 signing key so wings can auth against any node:
+Generate an EC P-256 signing key so wings can authenticate against any public
+process:
 
-```
+```sh
 fly secrets set WT_JWT_KEY=$(wt keygen)
 ```
 
-## Deploy
+## Release and deploy the login-only configuration
 
 The public website and installer are one versioned contract. Publish and verify the
-matching GitHub release before deploying the site that documents it. From the exact
+matching GitHub release before deploying a site that documents it. From the exact
 commit being promoted:
 
-```
+```sh
 git tag vX.Y.Z
 git push origin vX.Y.Z
-# wait for the release workflow to pass and publish all five assets
+# wait for the release workflow to publish all five assets
 gh release view vX.Y.Z
 curl -fsSL https://wingthing.ai/install.sh | sh
 make deploy
 ```
 
-`make deploy` runs the local build/tests, release command-surface contract, and
-real N-1/current rolling-upgrade compatibility gate before `fly deploy`; it does
-not publish a GitHub release. The compatibility gate requires the published
-baseline tag, so deploy from a full clone with tags. Deploying first creates an
-installation outage: the newer site serves an installer that correctly refuses an
-older binary whose command surface does not match the documentation. Verify that
-the installed binary reports `vX.Y.Z` before continuing.
+`make deploy` runs the web build, Go tests, binary build, release command-surface
+contract, and the configured historical-baseline compatibility gate before
+`fly deploy`; it does not publish a GitHub release. The compatibility script uses
+`WT_COMPAT_BASELINE_REF` when set and otherwise uses the pinned default declared in
+`scripts/test-backward-compat.sh`. It exercises that baseline and the candidate in
+both gateway/wing orders; it is not a claim that the pin is always the immediately
+previous release, and it does not exercise a mixed Fly login/edge fleet.
 
-Fly may roll the login and edge processes independently. The wire changes in this
-release are additive, so mixed versions preserve the historical relay behavior, but
-the new `direct-free` restriction is not a completed security boundary until every
-gateway process is current. Check every machine and its image digest before declaring
-the policy active.
+Deploying the site before the matching release creates an installation outage: the
+newer installer refuses an older binary whose command surface does not match the
+site. Confirm that the installed binary reports `vX.Y.Z` before continuing.
 
-Current edges proxy the portal HTML and hashed static assets to the login process,
-so one page load cannot mix bundles from two releases. The release that introduced
-that rule needs one special split-fleet order: update every edge process first, then
-update login. An older edge serves its own assets, so updating login first can pair a
-new index with an old missing asset during that first rollout. The checked-in Fly
-configuration currently exposes only the login process; this ordering applies when
-the optional edge group is enabled. After every edge runs this release, ordinary
-rolling order is safe for static assets.
+The new `direct-free` restriction is not a completed security boundary until every
+public gateway process is current. Check every live machine and image digest before
+declaring the policy active.
 
-For that one split-fleet transition, run the gates above and deploy the same
-checked-out commit in this order instead of using the all-groups `make deploy`:
+## Hosted relay policy
 
-```bash
-fly deploy --process-groups edge
-# verify every edge is healthy and running the new image
-fly deploy --process-groups login
-```
-
-### Hosted relay policy
-
-The `wt serve` gateway defaults to the backward-compatible `legacy` policy so an
-upgrade cannot silently change an existing private gateway. The checked-in Fly
-configuration explicitly sets `WT_RELAY_POLICY=direct-free`: free accounts may
-use login, the wing directory, key exchange, bounded discovery/passkey messages,
-and WebRTC signaling, but PTY and general control payload relay is denied. Pro
-users retain relay access.
+`wt serve` defaults to the backward-compatible `legacy` policy so an upgrade does
+not silently change a private gateway. The checked-in Fly configuration explicitly
+sets `WT_RELAY_POLICY=direct-free`: free accounts can use login, the authorized wing
+directory, key exchange, bounded discovery/passkey messages, and WebRTC signaling,
+but the gateway denies PTY and general control payload relay. Accounts with relay
+access retain that hosted browser transport.
 
 On `direct-free`, the historical billing-free personal and organization upgrade
-endpoints are disabled, and the account UI does not offer plan mutation. Existing
-Pro/team entitlements and cancellation paths remain valid; new relay entitlements
-must be provisioned by the deployment's billing or operator workflow. Legacy and
-self-hosted gateways retain their previous self-service behavior. This does not
-remove organization membership or wing sharing; it only prevents those endpoints
-from granting new hosted-relay entitlement.
+endpoints are disabled, and the account UI does not grant relay access. Existing
+entitlements and cancellation paths remain valid; new relay access must come from
+the deployment's billing or operator workflow. Private legacy gateways and
+self-hosted roosts retain their operator-controlled relay behavior. A wing with
+`hosted_relay: deny` refuses relayed payloads even when the account or self-hosted
+gateway would otherwise permit them.
 
-The public deployment also sets an explicit temporary migration boundary in
-`fly.toml`. Accounts created on or before that instant retain relay parity while
-the transition is active. If the boundary changes, update the same RFC3339 value
-on every login and edge process:
+The checked-in configuration also sets the migration cutoff explicitly:
 
 ```text
 WT_RELAY_MIGRATION_BEFORE=2026-08-26T00:00:00Z
 ```
 
-`WT_RELAY_GRANDFATHER_BEFORE` remains a deprecated compatibility alias. Startup
-fails if both names are set to different values. The logged-in API reports
-`relay_allowed` and `relay_reason`, and edge entitlement sync carries the same
-decision made by the login node.
+Accounts created on or before that instant retain temporary relay parity while the
+migration rule is active. If the value changes, deploy the same RFC3339 value to all
+gateway processes. Startup fails when the current and deprecated cutoff variable
+names are both present with different values. The logged-in API publishes
+`relay_allowed` and `relay_reason`; an enabled edge synchronizes the login node's
+decision.
 
-## Scale
+## Enable the optional edge group
 
-### Add edge nodes to a region
+Do this only when edge capacity is intentionally part of the deployment. Two edits
+are required in `fly.toml` before scaling:
 
+1. Uncomment `[processes].edge`.
+2. Change the HTTP service attachment to:
+
+   ```toml
+   processes = ["login", "edge"]
+   ```
+
+Then deploy that configuration before creating edge machines:
+
+```sh
+fly deploy
+make status
+make deploy-edge REGIONS=nrt COUNT=1
+make deploy-edge REGIONS=lhr COUNT=1
 ```
-make deploy-edge REGIONS=nrt COUNT=1      # 1 edge in Tokyo
-make deploy-edge REGIONS=lhr COUNT=1      # 1 edge in London
-make deploy-edge REGIONS=nrt,lhr COUNT=2  # 2 edges split across Tokyo + London
-```
 
-### Set total counts
+`make deploy-edge` only changes the edge count in the named regions. It now refuses
+to run while the process command is commented out or the HTTP service excludes
+`edge`. After scaling, use `make status`, check `/health` through the public service,
+and inspect each process's startup log. Edge logs must say `auto-detected node role:
+edge` and name the derived or configured login address; login logs must say
+`auto-detected node role: login`.
 
-```
+Current edges proxy portal HTML and hashed static assets to login, so those assets
+come from the login release. When introducing that proxy rule to a fleet containing
+older edges, update and verify edges before updating login; after that transition,
+keep login and edge on the same promoted image rather than assuming the historical
+compatibility pin covers mixed edge releases.
+
+To set total counts across the process groups after edge is enabled:
+
+```sh
 make scale LOGIN=1 EDGE=3
 ```
 
-### Check what's running
+To remove Tokyo edges, or every edge respectively:
 
-```
-make status
-```
-
-## Middle-of-the-night playbook
-
-Only use this after the matching release has passed the promotion sequence above:
-
-```
-make deploy
-make deploy-edge REGIONS=nrt,lhr,cdg COUNT=1
-```
-
-That's it. One login in ewr, one edge each in Tokyo, London, Paris. Wings and browsers auto-route to nearest via Fly anycast.
-
-## Region codes
-
-| Code | City |
-|------|------|
-| ewr | Newark (login node) |
-| nrt | Tokyo |
-| lhr | London |
-| cdg | Paris |
-| sin | Singapore |
-| syd | Sydney |
-| gru | São Paulo |
-| sea | Seattle |
-| ord | Chicago |
-| iad | Ashburn |
-
-Full list: `fly platform regions`
-
-## How it works
-
-1. `fly deploy` builds the Docker image and deploys to all machines
-2. Login machine has the `wt_data` volume → auto-detects as login
-3. Edge machines have no volume → auto-detect as edge
-4. Edges proxy API/auth requests to login over Fly's private 6PN network
-5. Edges cache entitlements (polled every 60s) and sessions (cached 5min)
-6. Login drives gossip: pushes wing online/offline events to edges every 2s
-7. If a browser on an edge needs a wing on another node, `fly-replay` header redirects the WebSocket upgrade transparently
-
-## Removing edge nodes
-
-```
-fly scale count edge=0 --region nrt    # remove Tokyo edges
-```
-
-Or remove all edges:
-
-```
+```sh
+fly scale count edge=0 --region nrt
 make scale LOGIN=1 EDGE=0
 ```
 
-## Self-hosted
+After the last edge is removed, return `fly.toml` to its checked-in login-only form
+if edge is no longer an intended deployment option: remove `"edge"` from
+`http_service.processes`, comment the edge command, and deploy that configuration.
 
-The simplest self-hosted deployment is a single node with no `WT_NODE_ROLE`, no
-`FLY_MACHINE_ID`, no gossip, and no `fly-replay`: use `wt roost start` for the
-portal, gateway, and embedded wing, or `wt serve` for the gateway alone. An
-OAuth gateway or roost should set `WT_ROOST_ALLOWED_EMAILS`; OAuth identifies an
-account but does not by itself enroll that account in a private service. All
-multi-node code paths are gated on Fly environment variables being present.
-If you deliberately build a split non-Fly deployment, set the same high-entropy
-`WT_INTERNAL_SECRET` on every node. Wingthing's built-in node clients send it as
-`X-Internal-Secret`; keep the node transport private (and encrypted when it can
-cross an untrusted network). Do not reuse `WT_JWT_KEY` for that purpose.
+## Optional edge request path
+
+When the edge group is enabled and attached to the HTTP service:
+
+1. the login machine is the only process with `wt_data`;
+2. an edge starts without `/data`, detects `edge`, and skips SQLite;
+3. login-owned HTTP and API work is proxied over the private Fly address;
+4. the edge synchronizes login-owned session, entitlement, and wing state; and
+5. a WebSocket for a wing connected elsewhere can receive a `fly-replay` response
+   that asks Fly to replay the upgrade on the owning machine.
+
+These are optional code paths, not a description of the active checked-in topology.
+
+## Self-hosted contrast
+
+The simplest self-hosted deployment is one process with no `WT_NODE_ROLE`,
+`FLY_MACHINE_ID`, gossip, or `fly-replay`: use `wt roost start` for a portal,
+gateway, and embedded wing, or `wt serve` for the gateway alone. A private OAuth
+gateway or roost should set `WT_ROOST_ALLOWED_EMAILS`; OAuth authenticates an
+account but does not enroll it in a private service. Self-hosted relay policy is
+operator-controlled and does not depend on a wingthing.ai hosted-relay entitlement.

--- a/docs/sandbox-enhancement-design.md
+++ b/docs/sandbox-enhancement-design.md
@@ -245,9 +245,10 @@ unlisted webhook—stops working.
 There is a second, explicit compatibility change: on Linux `network: "*"` now
 allows any TCP destination presented through HTTP CONNECT, but no longer creates
 a general routed interface. Ordinary raw-socket clients, UDP, ICMP, and programs
-that ignore proxy configuration fail. macOS `network: "*"` retains its unrestricted Seatbelt
-network behavior. This asymmetry is visible in `wt egg explain`; it must not be
-described as byte-for-byte runtime compatibility.
+that ignore proxy configuration fail. On macOS, `network: "*"` emits no Seatbelt
+network deny and therefore leaves networking subject to the host OS and any outer
+boundary. This asymmetry is visible in `wt egg explain`; it must not be described
+as byte-for-byte runtime compatibility.
 
 This is the "less anything insecure" carve-out. It is also the entire point: the
 policy starts meaning what it says. But it will break real setups, so it ships

--- a/docs/skills/create-egg/SKILL.md
+++ b/docs/skills/create-egg/SKILL.md
@@ -89,7 +89,13 @@ fs:
 
 ### 2. NEVER use `network: "*"` unless the user can justify it
 
-Unrestricted network defeats the entire sandbox. The agent can exfiltrate anything it can read. Push back hard. Most "I need network" requests are actually "I need one or two specific domains":
+This is the broadest egress policy and can let the agent exfiltrate readable data.
+Do not describe it as one uniform raw-networking mode. Linux permits any TCP
+destination presented through HTTP CONNECT but retains a route-less namespace, so
+ordinary raw sockets, UDP, ICMP, and clients that ignore the proxy still fail. On
+macOS the wildcard emits no Seatbelt network deny, leaving host networking subject
+to the OS and any outer boundary. Push back hard. Most "I need network" requests
+are actually "I need one or two specific domains":
 
 - Need npm? Add `"registry.npmjs.org"` and `"*.npmjs.org"`
 - Need pip? Add `"pypi.org"` and `"files.pythonhosted.org"`

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -13,7 +13,7 @@ disagree about which sessions exist.
 | `make check` | web build, `make test`, binary build | every tagged and external E2E tier |
 | `make test-vuln` | pinned `govulncheck` plus npm's current advisory database | unreachable vulnerable Go symbols and non-Go/npm dependencies |
 | `make test-integ` | in-process relay, PTY routing, P2P, tunnel, and synthetic agent lifecycle | native sandbox enforcement and browser rendering |
-| `make test-compat` | real last-release and candidate binaries: historical migrations, CLI/flag surface, task-state round trip, both gateway/wing upgrade orders, PTY startup, and rollback reopen | third-party wrappers and unsupported pre-baseline releases |
+| `make test-compat` | real configured-baseline and candidate binaries: historical migrations, CLI/flag surface, task-state round trip, both gateway/wing upgrade orders, PTY startup, and rollback reopen. `WT_COMPAT_BASELINE_REF` overrides the script's pinned default | third-party wrappers, releases newer than a stale pin, and unsupported pre-baseline releases |
 | `make test-linux` | Debian container with privileged Linux sandbox, CLI, and namespace batteries | Ubuntu-specific behavior |
 | `make test-linux-ubuntu` | Ubuntu 24.04 version of the Linux battery | macOS and browser |
 | `make test-web` | seeded organization-mode roost (including per-identity provider-profile routing), empty-enrollment legacy org canary, and hosted direct-free/relay-entitlement deployments driven by Playwright | local MCP, headless runs, real OAuth provider |
@@ -184,7 +184,8 @@ sufficient for authorization, transport, persistence, or sandbox work.
 
 Do not chase a repository-wide coverage percentage. Require evidence for claims:
 owner access is paired with outsider denial, allowed egress with proxy bypass denial,
-fresh schema with deployed-schema upgrade, new/new components with N-1/N behavior,
+fresh schema with deployed-schema upgrade, new/new components with the explicitly
+configured historical-baseline/candidate behavior,
 and successful lifecycle with cancellation/restart. Every dogfood bug gets the
 narrowest deterministic regression test that would have caught it.
 
@@ -196,8 +197,9 @@ The current CI shape is:
 - required Linux jobs: Debian and Ubuntu native-architecture batteries;
 - required browser job: `make test-web`;
 - required compatibility job: immutable historical migrations, CLI/flag surface,
-  task-store round trips, and live N-1/N gateway-wing PTY tests in both upgrade
-  orders; the browser job adds the four-principal organization-mode and legacy
+  task-store round trips, and live configured-baseline/candidate gateway-wing PTY
+  tests in both upgrade orders; the browser job adds the four-principal
+  organization-mode and legacy
   enrollment suites;
 - scheduled or protected-environment job: published agent and hosted-model
   canaries; and

--- a/fly.toml
+++ b/fly.toml
@@ -8,6 +8,8 @@ primary_region = "ewr"
 
 [processes]
   login = "sh -c 'umask 077 && mkdir -p /data/.wingthing && HOME=/data exec ./wt serve --addr :8080'"
+  # Optional edges are disabled in the checked-in deployment. Enabling them also
+  # requires adding "edge" to http_service.processes before deploy and scale.
   # edge = "./wt serve --addr :8080"
 
 [env]
@@ -45,10 +47,11 @@ primary_region = "ewr"
   memory = "512mb"
   processes = ["login"]
 
-# Horizontal scaling — uncomment edge process above, then:
-#   fly deploy
-#   fly scale count login=1 edge=3
-#   fly scale count edge=2 --region nrt,lhr
+# Optional edge rollout:
+#   1. Uncomment the edge process above.
+#   2. Change http_service.processes to ["login", "edge"].
+#   3. Run fly deploy and verify login remains healthy.
+#   4. Scale edges, for example: fly scale count edge=2 --region nrt,lhr
 #
 # One-time setup:
 #   fly secrets set WT_JWT_KEY=$(wt keygen)

--- a/internal/docscheck/docs_test.go
+++ b/internal/docscheck/docs_test.go
@@ -69,6 +69,11 @@ func TestPublicDocumentationContractsStayAligned(t *testing.T) {
 	root := repositoryRoot(t)
 	publicFiles := []string{
 		"README.md",
+		"SKILL.md",
+		"docs/fly-ops.md",
+		"docs/sandbox.md",
+		"docs/security.md",
+		"docs/skills/create-egg/SKILL.md",
 		"web/index.html",
 		"internal/relay/templates/docs.html",
 		"internal/relay/templates/patterns.html",
@@ -104,13 +109,16 @@ func TestPublicDocumentationContractsStayAligned(t *testing.T) {
 	}
 
 	mustContain := map[string][]string{
-		"README.md": {"WT_ROOST_ALLOWED_EMAILS", "never silently falls back"},
-		"patterns/shared-web-roost/INSTRUCTIONS.md": {"WT_ROOST_ALLOWED_EMAILS", "OAuth by itself proves"},
-		"internal/relay/templates/docs.html":        {"WT_BASE_URL=https://roost.example.com", "WT_ROOST_ALLOWED_EMAILS", "wt roost start --addr :8080", "wt serve --addr :8080", "never silently changes", "gateway database contains", "does not let an account grant itself relay access", "no request happens until you choose load or open", "200,000 serialized terminal characters", "a wing binary from before", "stop or isolate the wing"},
-		"internal/relay/templates/privacy.html":     {"gateway database contains", "embedded wing separately keeps", "200,000 serialized terminal characters", "Clearing the site's browser data removes"},
-		"fly.toml":                                  {`WT_RELAY_POLICY = "direct-free"`, "WT_RELAY_MIGRATION_BEFORE"},
-		"docs/security.md":                          {"not a downgrade-compatible security policy", "stop the wing or isolate it"},
-		"docs/fly-ops.md":                           {"matching GitHub release", "it does not", "publish a GitHub release", "not a completed security boundary until every"},
+		"README.md": {"WT_ROOST_ALLOWED_EMAILS", "never silently falls back", "first log\nin and start Wingthing on every execution machine"},
+		"SKILL.md":  {"every execution machine must run `wt login` and `wt start`", "both account-level hosted-relay access", "does not require a wingthing.ai hosted-relay entitlement"},
+		"patterns/shared-web-roost/INSTRUCTIONS.md":    {"WT_ROOST_ALLOWED_EMAILS", "OAuth by itself proves"},
+		"patterns/hosted-browser-wing/INSTRUCTIONS.md": {"Account access and wing policy are independent", "wt login", "wt start", "self-hosted roost", "application-encrypted"},
+		"internal/relay/templates/docs.html":           {"WT_BASE_URL=https://roost.example.com", "WT_ROOST_ALLOWED_EMAILS", "wt roost start --addr :8080", "wt serve --addr :8080", "never silently changes", "gateway database contains", "does not let an account grant itself relay access", "no request happens until you choose load or open", "200,000 serialized terminal characters", "a wing binary from before", "stop or isolate the wing", "On every execution machine", "wt login", "wt start"},
+		"internal/relay/templates/patterns.html":       {"/patterns/hosted-browser-wing/INSTRUCTIONS.md", "account with hosted-relay access", "hosted browser -> encrypted relay -> selected wing"},
+		"internal/relay/templates/privacy.html":        {"gateway database contains", "embedded wing separately keeps", "200,000 serialized terminal characters", "Clearing the site's browser data removes"},
+		"fly.toml":                                     {`WT_RELAY_POLICY = "direct-free"`, "WT_RELAY_MIGRATION_BEFORE"},
+		"docs/security.md":                             {"not a downgrade-compatible security policy", "stop the wing or isolate it"},
+		"docs/fly-ops.md":                              {"matching GitHub release", "it does not", "publish a GitHub release", "not a completed security boundary until every", "active `fly.toml` is deliberately login-only", "Two edits", `processes = ["login", "edge"]`, "does not exercise a mixed Fly login/edge fleet"},
 	}
 	for rel, phrases := range mustContain {
 		data, readErr := os.ReadFile(filepath.Join(root, rel))
@@ -166,6 +174,101 @@ func TestPublicDocumentationContractsStayAligned(t *testing.T) {
 	}
 }
 
+func TestFlyOperationsDocumentationMatchesActiveConfiguration(t *testing.T) {
+	root := repositoryRoot(t)
+	read := func(rel string) string {
+		t.Helper()
+		data, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(data)
+	}
+
+	fly := read("fly.toml")
+	if !regexp.MustCompile(`(?m)^\s*login\s*=`).MatchString(fly) {
+		t.Fatal("fly.toml must define the active login process")
+	}
+	if regexp.MustCompile(`(?m)^\s*edge\s*=`).MatchString(fly) {
+		t.Fatal("the checked-in Fly contract expects the optional edge process to remain disabled")
+	}
+
+	httpStart := strings.Index(fly, "[http_service]")
+	if httpStart < 0 {
+		t.Fatal("fly.toml has no http_service section")
+	}
+	httpEnd := strings.Index(fly[httpStart+1:], "\n[")
+	if httpEnd < 0 {
+		httpEnd = len(fly) - httpStart - 1
+	}
+	httpService := fly[httpStart : httpStart+1+httpEnd]
+	if !strings.Contains(httpService, `processes = ["login"]`) || strings.Contains(httpService, `"edge"`) {
+		t.Fatalf("checked-in http_service must route only to login:\n%s", httpService)
+	}
+	for _, phrase := range []string{
+		`processes = ["login"]`,
+		`processes = ["login", "edge"]`,
+		"ordinary `fly deploy` of the checked-in file does not create or route",
+		"before creating edge machines",
+	} {
+		if !strings.Contains(read("docs/fly-ops.md"), phrase) {
+			t.Errorf("docs/fly-ops.md must contain %q", phrase)
+		}
+	}
+
+	makefile := read("Makefile")
+	for _, phrase := range []string{"edge process is disabled in fly.toml", "edge is not attached to http_service.processes"} {
+		if !strings.Contains(makefile, phrase) {
+			t.Errorf("deploy-edge must guard the inactive Fly topology with %q", phrase)
+		}
+	}
+
+	serve := read("cmd/wt/serve.go")
+	detect := strings.Index(serve, `if runtime.flyMachineID != "" && runtime.nodeRole == ""`)
+	load := strings.Index(serve, "cfg, err := config.Load()")
+	if detect < 0 || load < 0 || detect > load {
+		t.Fatal("Fly role detection must remain before config.Load so config initialization cannot fabricate /data")
+	}
+}
+
+func TestCompatibilityDocumentationNamesTheConfiguredBaseline(t *testing.T) {
+	root := repositoryRoot(t)
+	checks := []struct {
+		path        string
+		mustHave    string
+		mustNotHave []string
+	}{
+		{path: "Makefile", mustHave: "configured historical", mustNotHave: []string{"against the last published"}},
+		{path: "docs/fly-ops.md", mustHave: "configured historical-baseline", mustNotHave: []string{"real N-1/current"}},
+		{path: "docs/testing.md", mustHave: "configured-baseline and candidate", mustNotHave: []string{"real last-release", "live N-1/N gateway-wing"}},
+		{path: "docs/direct-agent-manager-design.md", mustHave: "configured historical baseline", mustNotHave: []string{"runs real N-1 and candidate"}},
+		{path: "docs/bryan-wingthing-direct-control-field-report.md", mustHave: "configured historical-baseline/candidate", mustNotHave: []string{"real N-1/candidate"}},
+	}
+	for _, check := range checks {
+		data, err := os.ReadFile(filepath.Join(root, check.path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := string(data)
+		if !strings.Contains(text, check.mustHave) {
+			t.Errorf("%s must name %q", check.path, check.mustHave)
+		}
+		for _, stale := range check.mustNotHave {
+			if strings.Contains(text, stale) {
+				t.Errorf("%s overstates the pinned compatibility gate with %q", check.path, stale)
+			}
+		}
+	}
+
+	script, err := os.ReadFile(filepath.Join(root, "scripts/test-backward-compat.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(script), `BASELINE_REF="${WT_COMPAT_BASELINE_REF:-`) {
+		t.Fatal("compatibility script must keep an explicit overridable baseline")
+	}
+}
+
 func TestCurrentDesignDocsDoNotHardCodeMCPToolCounts(t *testing.T) {
 	root := repositoryRoot(t)
 	// Tool membership is a tested contract in internal/control. Numeric prose
@@ -196,8 +299,13 @@ func TestSandboxDocumentationMatchesImplementedBoundary(t *testing.T) {
 	}{
 		{
 			path:        "docs/skills/create-egg/SKILL.md",
-			mustHave:    []string{"HOME write isolation", "not a filesystem allowlist", "locations outside HOME"},
-			mustNotHave: []string{"root filesystem read-only", "read-only root mount"},
+			mustHave:    []string{"HOME write isolation", "not a filesystem allowlist", "locations outside HOME", "one uniform raw-networking mode", "route-less namespace", "no Seatbelt network deny"},
+			mustNotHave: []string{"root filesystem read-only", "read-only root mount", "Unrestricted network defeats"},
+		},
+		{
+			path:        "docs/egg-inheritance-design.md",
+			mustHave:    []string{"broadest platform policy", "any CONNECT destination on Linux without a general route", "macOS emits no Seatbelt network deny"},
+			mustNotHave: []string{`"*" in any layer = full network`},
 		},
 		{
 			path:        "docs/container-mode.md",

--- a/internal/docscheck/docs_test.go
+++ b/internal/docscheck/docs_test.go
@@ -75,6 +75,8 @@ func TestPublicDocumentationContractsStayAligned(t *testing.T) {
 		"docs/security.md",
 		"docs/skills/create-egg/SKILL.md",
 		"web/index.html",
+		"internal/relay/templates/base.html",
+		"internal/relay/templates/home.html",
 		"internal/relay/templates/docs.html",
 		"internal/relay/templates/patterns.html",
 		"internal/relay/templates/privacy.html",
@@ -113,8 +115,10 @@ func TestPublicDocumentationContractsStayAligned(t *testing.T) {
 		"SKILL.md":  {"every execution machine must run `wt login` and `wt start`", "both account-level hosted-relay access", "does not require a wingthing.ai hosted-relay entitlement"},
 		"patterns/shared-web-roost/INSTRUCTIONS.md":    {"WT_ROOST_ALLOWED_EMAILS", "OAuth by itself proves"},
 		"patterns/hosted-browser-wing/INSTRUCTIONS.md": {"Account access and wing policy are independent", "wt login", "wt start", "self-hosted roost", "application-encrypted"},
-		"internal/relay/templates/docs.html":           {"WT_BASE_URL=https://roost.example.com", "WT_ROOST_ALLOWED_EMAILS", "wt roost start --addr :8080", "wt serve --addr :8080", "never silently changes", "gateway database contains", "does not let an account grant itself relay access", "no request happens until you choose load or open", "200,000 serialized terminal characters", "a wing binary from before", "stop or isolate the wing", "On every execution machine", "wt login", "wt start"},
-		"internal/relay/templates/patterns.html":       {"/patterns/hosted-browser-wing/INSTRUCTIONS.md", "account with hosted-relay access", "hosted browser -> encrypted relay -> selected wing"},
+		"internal/relay/templates/base.html":           {`href="/install" class="nav-cta">install locally`, `href="/login">login`, ">open app</a>"},
+		"internal/relay/templates/home.html":           {"local-first control for coding agents", "wt mcp stdio", "wt egg", "wt mcp connect", "wt serve --local --https", "optional hosted browser"},
+		"internal/relay/templates/docs.html":           {"WT_BASE_URL=https://roost.example.com", "WT_ROOST_ALLOWED_EMAILS", "wt roost start --addr :8080", "wt serve --addr :8080", "never silently changes", "gateway database contains", "does not let an account grant itself relay access", "no request happens until you choose load or open", "200,000 serialized terminal characters", "a wing binary from before", "stop or isolate the wing", "Remote execution through direct MCP or the hosted browser needs a running wing", "do not require a separate wing daemon", "connector token", "wt login", "wt start"},
+		"internal/relay/templates/patterns.html":       {"/patterns/hosted-browser-wing/INSTRUCTIONS.md", "account with hosted-relay access", "hosted browser -> encrypted relay -> selected wing", "authorization for the connector account", "parent/connector needs"},
 		"internal/relay/templates/privacy.html":        {"gateway database contains", "embedded wing separately keeps", "200,000 serialized terminal characters", "Clearing the site's browser data removes"},
 		"fly.toml":                                     {`WT_RELAY_POLICY = "direct-free"`, "WT_RELAY_MIGRATION_BEFORE"},
 		"docs/security.md":                             {"not a downgrade-compatible security policy", "stop the wing or isolate it"},
@@ -164,13 +168,201 @@ func TestPublicDocumentationContractsStayAligned(t *testing.T) {
 		t.Fatal(err)
 	}
 	installText := string(install)
-	for _, phrase := range []string{"wt roost start --https", "wt mcp connect", "hosted browser terminal and control relay require relay access", "certutil"} {
+	for _, phrase := range []string{"wt roost start --https", "wt mcp connect", "connector token", "authorized for the connector account", "hosted browser terminal and control relay require relay access", "certutil"} {
 		if !strings.Contains(installText, phrase) {
 			t.Errorf("public install flow must contain %q", phrase)
 		}
 	}
 	if strings.Contains(strings.ToLower(installText), "single binary, no dependencies") {
 		t.Fatal("public install flow hides optional HTTPS and agent CLI dependencies")
+	}
+}
+
+func TestPublicEntryPointsKeepLocalAgentFirstHierarchy(t *testing.T) {
+	root := repositoryRoot(t)
+	read := func(rel string) string {
+		t.Helper()
+		data, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(data)
+	}
+
+	ordered := map[string][]string{
+		"README.md": {
+			"## 1. Local agent control: stdio MCP",
+			"## 2. Local human terminal: sandboxed agent",
+			"## 3. Different machines: direct remote MCP",
+			"## 4. Browser visibility: self-hosted roost",
+			"## 5. Hosted browser relay: entitled and optional",
+		},
+		"SKILL.md": {
+			"1. **Local agent control:**",
+			"2. **Local human terminal:**",
+			"3. **Direct remote MCP:**",
+			"4. **Self-hosted browser:**",
+			"5. **Optional hosted browser:**",
+		},
+		"patterns/SKILL.md": {
+			"1. **Local agent control with stdio MCP:**",
+			"2. **Local sandboxed agent terminal for a person:**",
+			"3. **Direct remote MCP when machines differ:**",
+			"4. **Self-hosted roost when a person needs a browser:**",
+			"5. **Optional entitled hosted relay:**",
+		},
+	}
+	for _, rel := range []string{
+		"internal/relay/templates/home.html",
+		"internal/relay/templates/docs.html",
+		"internal/relay/templates/install.html",
+		"internal/relay/templates/patterns.html",
+	} {
+		ordered[rel] = []string{
+			`data-route="local-agent"`,
+			`data-route="local-human"`,
+			`data-route="direct-remote"`,
+			`data-route="self-hosted-browser"`,
+			`data-route="hosted-relay"`,
+		}
+	}
+
+	for rel, markers := range ordered {
+		text := read(rel)
+		previous := -1
+		for _, marker := range markers {
+			index := strings.Index(text, marker)
+			if index < 0 {
+				t.Errorf("%s is missing hierarchy marker %q", rel, marker)
+				continue
+			}
+			if index <= previous {
+				t.Errorf("%s places %q out of local-agent-first order", rel, marker)
+			}
+			previous = index
+		}
+	}
+
+	contracts := map[string][]string{
+		"README.md": {
+			"using the code and provider login already\nthere",
+			"No Wingthing account or wing daemon is\nrequired",
+			"It never silently falls back to the hosted relay",
+			"run the browser portal locally first",
+			"already has hosted-relay access",
+		},
+		"internal/relay/templates/home.html": {
+			"<code>wt mcp stdio</code> · no account or daemon",
+			"<code>wt egg</code> · sandboxed and attachable",
+			"direct remote MCP to an explicit wing",
+			"<code>wt serve --local --https</code> · self-host first",
+			"requires hosted-relay entitlement and an allowing wing",
+		},
+		"internal/relay/templates/docs.html": {
+			"existing project directories and the current OS user's existing provider logins",
+			"connector token",
+			"Run <code>wt start</code> on the parent only when that machine also executes agents",
+			"The connector never silently changes to hosted relay",
+			"Remote execution through direct MCP or the hosted browser needs a running wing",
+			"do not require a separate wing daemon",
+			"This self-hosted route needs no Wingthing account or hosted-relay entitlement",
+			"requires an account with hosted-relay access",
+		},
+		"internal/relay/templates/install.html": {
+			"Child agents use the existing code and provider login on this computer",
+			"authorized for the connector account",
+			"parent/connector machine",
+			"connector token",
+			"Run <code>wt start</code> on the parent only when that machine also executes agents",
+			"never silently fall back to hosted relay",
+			"No Wingthing account or hosted-relay entitlement is required",
+			"hosted browser terminal and control relay require relay access",
+		},
+		"internal/relay/templates/patterns.html": {
+			"parent AI -> local stdio MCP -> local child agents",
+			"person -> local sandboxed agent terminal -> reattach later",
+			"parent AI -> direct remote MCP -> selected wing -> agent",
+			"authorization for the connector account (personal or organization)",
+			"The parent/connector needs:",
+			"localhost browser -> local portal -> SSH tunnel -> remote wing -> agent",
+			"hosted browser -> encrypted relay -> selected wing -> agent",
+		},
+	}
+	for rel, phrases := range contracts {
+		text := read(rel)
+		for _, phrase := range phrases {
+			if !strings.Contains(text, phrase) {
+				t.Errorf("%s must preserve hierarchy contract %q", rel, phrase)
+			}
+		}
+	}
+}
+
+func TestUsageRecipesPointToTheCorrectRoute(t *testing.T) {
+	root := repositoryRoot(t)
+	contracts := map[string][]string{
+		"patterns/local-subagents/INSTRUCTIONS.md": {
+			"Start here",
+			"Local stdio MCP uses the code and provider logins already on\nthis machine",
+			"no Wingthing account, daemon, roost, or hosted relay",
+		},
+		"patterns/local-sandbox/INSTRUCTIONS.md": {
+			"when a person wants a local sandboxed",
+			"local stdio MCP setup",
+		},
+		"patterns/remote-orchestration/INSTRUCTIONS.md": {
+			"only when the parent agent and execution wing are on different",
+			"prefer\nlocal `wt mcp stdio`",
+			"does not proxy direct MCP payloads or silently switch",
+		},
+		"patterns/personal-remote-wing/INSTRUCTIONS.md": {
+			"when a person needs browser visibility",
+			"the first browser route to consider",
+			"does not use wingthing.ai or require a hosted-relay entitlement",
+		},
+		"patterns/hosted-browser-wing/INSTRUCTIONS.md": {
+			"Use this optional route only",
+			"Prefer\na self-hosted roost",
+			"already has hosted-relay access",
+		},
+	}
+	for rel, phrases := range contracts {
+		data, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := string(data)
+		for _, phrase := range phrases {
+			if !strings.Contains(text, phrase) {
+				t.Errorf("%s must preserve route contract %q", rel, phrase)
+			}
+		}
+	}
+}
+
+func TestRemoteOrchestrationParentUsesAuthorizedAccount(t *testing.T) {
+	root := repositoryRoot(t)
+	data, err := os.ReadFile(filepath.Join(root, "patterns/remote-orchestration/INSTRUCTIONS.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	start := strings.Index(text, "## 2. Connect the parent AI")
+	end := strings.Index(text, "## 3. Use it")
+	if start < 0 || end <= start {
+		t.Fatal("remote orchestration recipe must preserve the parent connector section")
+	}
+	parentSection := text[start:end]
+	for _, phrase := range []string{
+		"account authorized for the execution wings",
+		"personally or\nthrough organization membership",
+	} {
+		if !strings.Contains(parentSection, phrase) {
+			t.Errorf("parent connector instructions must contain %q", phrase)
+		}
+	}
+	if strings.Contains(parentSection, "same account") {
+		t.Error("parent connector instructions must not require the same account")
 	}
 }
 

--- a/internal/relay/pages.go
+++ b/internal/relay/pages.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ehrlich-b/wingthing/internal/egg"
 	patternfiles "github.com/ehrlich-b/wingthing/patterns"
 )
 
@@ -88,10 +89,22 @@ func (s *Server) template(cached *template.Template, files ...string) *template.
 }
 
 type pageData struct {
-	User      *User
-	LocalMode bool
-	HeroVideo bool
-	AppURL    string
+	User                        *User
+	LocalMode                   bool
+	HeroVideo                   bool
+	AppURL                      string
+	SandboxBuilderAgents        []string
+	SandboxBuilderAgentProfiles map[string]egg.AgentProfile
+}
+
+var sandboxBuilderAgents = []string{"claude", "codex", "cursor", "ollama", "gemini"}
+
+func sandboxBuilderAgentProfiles() map[string]egg.AgentProfile {
+	profiles := make(map[string]egg.AgentProfile, len(sandboxBuilderAgents))
+	for _, agent := range sandboxBuilderAgents {
+		profiles[agent] = egg.Profile(agent)
+	}
+	return profiles
 }
 
 type loginPageData struct {
@@ -109,7 +122,14 @@ func (s *Server) handleHome(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/app/", http.StatusSeeOther)
 		return
 	}
-	data := pageData{User: s.sessionUser(r), LocalMode: s.LocalMode, HeroVideo: s.Config.HeroVideo != "", AppURL: s.appURL()}
+	data := pageData{
+		User:                        s.sessionUser(r),
+		LocalMode:                   s.LocalMode,
+		HeroVideo:                   s.Config.HeroVideo != "",
+		AppURL:                      s.appURL(),
+		SandboxBuilderAgents:        sandboxBuilderAgents,
+		SandboxBuilderAgentProfiles: sandboxBuilderAgentProfiles(),
+	}
 	s.executePageTemplate(w, s.template(homeTmpl, "base.html", "home.html"), data)
 }
 

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -7,9 +7,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ehrlich-b/wingthing/internal/egg"
 )
 
 func mustTest(t *testing.T, err error) {
@@ -349,6 +352,7 @@ func TestPatternsPageExplainsOnlySupportedSetups(t *testing.T) {
 		"Run a durable, sandboxed agent on this computer",
 		"Let your current AI launch local sub-agents",
 		"Let one AI manage agents on several computers",
+		"Use the hosted browser on a remote wing",
 		"Control a remote agent from a localhost browser",
 		"Give a team a private browser-based agent host",
 		"Let an AI control agents on your private roost",
@@ -356,14 +360,15 @@ func TestPatternsPageExplainsOnlySupportedSetups(t *testing.T) {
 		"an enrolled account on a roost",
 		"You need:",
 		"You get:",
+		"hosted browser -> encrypted relay -> selected wing -> agent",
 		"localhost browser -> local portal -> SSH tunnel -> remote wing -> agent",
 	} {
 		if !strings.Contains(page, want) {
 			t.Errorf("/patterns does not contain %q", want)
 		}
 	}
-	if got := strings.Count(page, `<section class="pattern">`); got != 6 {
-		t.Errorf("/patterns contains %d setup cards, want 6", got)
+	if got := strings.Count(page, `<section class="pattern">`); got != 7 {
+		t.Errorf("/patterns contains %d setup cards, want 7", got)
 	}
 	for _, internal := range []string{
 		"the workflows people are asking for",
@@ -454,12 +459,53 @@ func TestSignedInHomeUsesConfiguredAppURLForLinkAndShortcut(t *testing.T) {
 	}
 }
 
+func TestHomeSandboxBuilderAgentProfilesMatchEggPolicy(t *testing.T) {
+	_, ts := testServer(t)
+	resp, err := http.Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	defer closeTestBody(t, resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET / status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read home page: %v", err)
+	}
+
+	const prefix = "var profiles="
+	start := strings.Index(string(body), prefix)
+	if start == -1 {
+		t.Fatal("home page omitted sandbox builder agent profiles")
+	}
+	encoded := string(body[start+len(prefix):])
+	end := strings.Index(encoded, ";")
+	if end == -1 {
+		t.Fatal("sandbox builder agent profiles were not terminated")
+	}
+
+	var rendered map[string]egg.AgentProfile
+	if err := json.Unmarshal([]byte(encoded[:end]), &rendered); err != nil {
+		t.Fatalf("decode sandbox builder agent profiles: %v", err)
+	}
+	if len(rendered) != len(sandboxBuilderAgents) {
+		t.Fatalf("rendered profiles = %d, want %d", len(rendered), len(sandboxBuilderAgents))
+	}
+	for _, agent := range sandboxBuilderAgents {
+		if got, want := rendered[agent], egg.Profile(agent); !reflect.DeepEqual(got, want) {
+			t.Errorf("rendered %s profile = %+v, want %+v", agent, got, want)
+		}
+	}
+}
+
 func TestPatternMarkdownRoutesServeCheckedInRecipes(t *testing.T) {
 	_, ts := testServer(t)
 	paths := []string{
 		"/patterns/SKILL.md",
 		"/patterns/local-sandbox/INSTRUCTIONS.md",
 		"/patterns/local-subagents/INSTRUCTIONS.md",
+		"/patterns/hosted-browser-wing/INSTRUCTIONS.md",
 		"/patterns/personal-remote-wing/INSTRUCTIONS.md",
 		"/patterns/shared-web-roost/INSTRUCTIONS.md",
 		"/patterns/shared-roost-agents/INSTRUCTIONS.md",

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -349,15 +349,19 @@ func TestPatternsPageExplainsOnlySupportedSetups(t *testing.T) {
 	}
 	page := body.String()
 	for _, want := range []string{
-		"Run a durable, sandboxed agent on this computer",
 		"Let your current AI launch local sub-agents",
+		"Run a durable, sandboxed agent on this computer",
 		"Let one AI manage agents on several computers",
-		"Use the hosted browser on a remote wing",
 		"Control a remote agent from a localhost browser",
 		"Give a team a private browser-based agent host",
 		"Let an AI control agents on your private roost",
+		"Use the entitled hosted browser on a remote wing",
 		"an exact email enrollment list",
 		"an enrolled account on a roost",
+		"Each execution wing needs:",
+		"authorization for the connector account (personal or organization)",
+		"The parent/connector needs:",
+		"It runs <code>wt start</code> only when it also executes agents.",
 		"You need:",
 		"You get:",
 		"hosted browser -> encrypted relay -> selected wing -> agent",
@@ -367,8 +371,28 @@ func TestPatternsPageExplainsOnlySupportedSetups(t *testing.T) {
 			t.Errorf("/patterns does not contain %q", want)
 		}
 	}
-	if got := strings.Count(page, `<section class="pattern">`); got != 7 {
+	if got := strings.Count(page, `<section class="pattern"`); got != 7 {
 		t.Errorf("/patterns contains %d setup cards, want 7", got)
+	}
+	previous := -1
+	for _, route := range []string{
+		`data-route="local-agent"`,
+		`data-route="local-human"`,
+		`data-route="direct-remote"`,
+		`data-route="self-hosted-browser"`,
+		`data-route="self-hosted-team"`,
+		`data-route="self-hosted-agent"`,
+		`data-route="hosted-relay"`,
+	} {
+		index := strings.Index(page, route)
+		if index < 0 {
+			t.Errorf("/patterns is missing route marker %q", route)
+			continue
+		}
+		if index <= previous {
+			t.Errorf("/patterns route marker %q is out of local-first order", route)
+		}
+		previous = index
 	}
 	for _, internal := range []string{
 		"the workflows people are asking for",
@@ -397,7 +421,8 @@ func TestPersonalRemoteWingGuideIsSelfHostedFirst(t *testing.T) {
 	}
 	guide := body.String()
 	for _, want := range []string{
-		"This is the smallest self-hosted setup. It does not use wingthing.ai.",
+		"This is the first browser route to consider and the smallest self-hosted setup.",
+		"does not use wingthing.ai or require a hosted-relay entitlement",
 		"wt serve --local --https",
 		"https://localhost:8443/app/",
 		"both private keys remain mode `0600` on this browser computer",
@@ -435,8 +460,14 @@ func TestSignedInDocumentationUsesThisRoostAppURL(t *testing.T) {
 			request.Host = "localhost"
 			recorder := httptest.NewRecorder()
 			server.ServeHTTP(recorder, request)
-			if !strings.Contains(recorder.Body.String(), `href="`+test.wantURL+`" class="nav-cta"`) {
+			rendered := recorder.Body.String()
+			if !strings.Contains(rendered, `href="`+test.wantURL+`" class="nav-cta">open app</a>`) {
 				t.Fatalf("documentation nav did not use app URL %q: %q", test.wantURL, recorder.Body.String())
+			}
+			for _, forbidden := range []string{">hosted app</a>", ">hosted login</a>"} {
+				if strings.Contains(rendered, forbidden) {
+					t.Errorf("documentation nav uses deployment-specific label %q", forbidden)
+				}
 			}
 		})
 	}
@@ -454,8 +485,141 @@ func TestSignedInHomeUsesConfiguredAppURLForLinkAndShortcut(t *testing.T) {
 	if !strings.Contains(rendered, `href="https://app.example.test/" class="prompt-line" id="prompt-app"`) {
 		t.Fatalf("signed-in home omitted configured app link: %q", rendered)
 	}
-	if strings.Contains(rendered, "h==='wingthing.ai'") || !strings.Contains(rendered, "app?app.href:'/login'") {
+	if !strings.Contains(rendered, `href="https://app.example.test/" class="nav-cta">open app</a>`) {
+		t.Fatalf("signed-in home omitted deployment-neutral app nav: %q", rendered)
+	}
+	if strings.Contains(rendered, ">hosted app</a>") || strings.Contains(rendered, ">hosted login</a>") {
+		t.Fatalf("signed-in home uses deployment-specific nav label: %q", rendered)
+	}
+	if strings.Contains(rendered, "h==='wingthing.ai'") || !strings.Contains(rendered, "app?app.href:'/install'") {
 		t.Fatalf("home keyboard shortcut is not driven by the configured app link: %q", rendered)
+	}
+}
+
+func TestPublicHomeLeadsWithLocalAgentFirstRoutes(t *testing.T) {
+	_, ts := testServer(t)
+	resp, err := http.Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	defer closeTestBody(t, resp.Body)
+	body := new(strings.Builder)
+	if _, err := io.Copy(body, resp.Body); err != nil {
+		t.Fatalf("read /: %v", err)
+	}
+	page := body.String()
+	previous := -1
+	for _, route := range []string{
+		`href="/patterns/local-subagents/INSTRUCTIONS.md" data-route="local-agent"`,
+		`href="/patterns/local-sandbox/INSTRUCTIONS.md" data-route="local-human"`,
+		`href="/patterns/remote-orchestration/INSTRUCTIONS.md" data-route="direct-remote"`,
+		`href="/patterns/personal-remote-wing/INSTRUCTIONS.md" data-route="self-hosted-browser"`,
+		`href="/patterns/hosted-browser-wing/INSTRUCTIONS.md" data-route="hosted-relay"`,
+	} {
+		index := strings.Index(page, route)
+		if index < 0 {
+			t.Fatalf("home is missing route %q", route)
+		}
+		if index <= previous {
+			t.Fatalf("home route %q is out of local-agent-first order", route)
+		}
+		previous = index
+	}
+	for _, contract := range []string{
+		"wt mcp stdio",
+		"no account or daemon",
+		"wt egg",
+		"wt mcp connect",
+		"direct remote MCP to an explicit wing",
+		"wt serve --local --https",
+		"self-host first",
+		"requires hosted-relay entitlement and an allowing wing",
+		`href="/install" class="nav-cta">install locally`,
+		`href="/login">login`,
+		`href="/install" class="prompt-line" id="prompt-app"`,
+	} {
+		if !strings.Contains(page, contract) {
+			t.Errorf("home does not contain hierarchy contract %q", contract)
+		}
+	}
+	for _, forbidden := range []string{">hosted app</a>", ">hosted login</a>"} {
+		if strings.Contains(page, forbidden) {
+			t.Errorf("home nav uses deployment-specific label %q", forbidden)
+		}
+	}
+}
+
+func TestPublicDocsAndInstallRenderLocalFirstHierarchy(t *testing.T) {
+	_, ts := testServer(t)
+	for _, test := range []struct {
+		path      string
+		contracts []string
+	}{
+		{
+			path: "/install",
+			contracts: []string{
+				"On each execution wing,",
+				"authorized for the connector account personally or through an organization",
+				"parent/connector machine",
+				"connector token",
+				"Run <code>wt start</code> on the parent only when that machine also executes agents",
+			},
+		},
+		{
+			path: "/docs",
+			contracts: []string{
+				"connector token",
+				"Run <code>wt start</code> on the parent only when that machine also executes agents",
+				"Remote execution through direct MCP or the hosted browser needs a running wing.",
+				"Local stdio MCP, local terminal commands, and an embedded self-hosted roost do not require a separate wing daemon.",
+			},
+		},
+	} {
+		t.Run(test.path, func(t *testing.T) {
+			resp, err := http.Get(ts.URL + test.path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", test.path, err)
+			}
+			defer closeTestBody(t, resp.Body)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("GET %s status = %d, want %d", test.path, resp.StatusCode, http.StatusOK)
+			}
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("read %s: %v", test.path, err)
+			}
+			page := string(body)
+			previous := -1
+			for _, route := range []string{
+				`data-route="local-agent"`,
+				`data-route="local-human"`,
+				`data-route="direct-remote"`,
+				`data-route="self-hosted-browser"`,
+				`data-route="hosted-relay"`,
+			} {
+				index := strings.Index(page, route)
+				if index < 0 {
+					t.Fatalf("%s is missing rendered route %q", test.path, route)
+				}
+				if index <= previous {
+					t.Fatalf("%s renders route %q out of local-agent-first order", test.path, route)
+				}
+				previous = index
+			}
+			for _, contract := range append(test.contracts,
+				`href="/install" class="nav-cta">install locally`,
+				`href="/login">login`,
+			) {
+				if !strings.Contains(page, contract) {
+					t.Errorf("%s does not contain rendered contract %q", test.path, contract)
+				}
+			}
+			for _, forbidden := range []string{">hosted app</a>", ">hosted login</a>"} {
+				if strings.Contains(page, forbidden) {
+					t.Errorf("%s uses deployment-specific nav label %q", test.path, forbidden)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/relay/templates/base.html
+++ b/internal/relay/templates/base.html
@@ -27,13 +27,18 @@ nav .logo:hover{color:var(--action)}
 .nav-cta:hover{background:var(--action-hover);color:#fff !important}
 .user-name{color:var(--text);font-size:13px}
 a{color:var(--action)}a:hover{color:var(--action-hover)}
-@media(max-width:600px){.container{padding:12px 12px}}
+@media(max-width:600px){
+  .container{padding:12px 12px}
+  .site-nav{align-items:flex-start;flex-wrap:wrap;gap:10px}
+  .site-nav .nav-links{width:100%;flex-wrap:wrap;gap:8px 12px}
+  .site-nav .user-name{max-width:100%;overflow-wrap:anywhere}
+}
 </style>
 {{block "head" .}}{{end}}
 </head>
 <body>
 <div class="container">
-<nav>
+<nav class="site-nav">
 <a href="/" class="logo">wingthing.ai</a>
 <div class="nav-links">
 <a href="/patterns">patterns</a>
@@ -42,7 +47,7 @@ a{color:var(--action)}a:hover{color:var(--action-hover)}
 {{if .User}}<a href="{{.AppURL}}" class="nav-cta">open app</a>
 {{if not .LocalMode}}<span class="user-name">{{.User.DisplayName}}</span>
 <form method="POST" action="/auth/logout" style="display:inline"><button type="submit" class="nav-btn">logout</button></form>{{end}}
-{{else}}<a href="/login" class="nav-cta">login</a>{{end}}
+{{else}}<a href="/install" class="nav-cta">install locally</a><a href="/login">login</a>{{end}}
 </div>
 </nav>
 {{template "content" .}}

--- a/internal/relay/templates/docs.html
+++ b/internal/relay/templates/docs.html
@@ -54,12 +54,12 @@
 </nav>
 <div class="docs-body">
 <h1>documentation</h1>
-<p class="lead">Wingthing is a typed agent manager for durable agent runs and terminals across local and remote wings, with human takeover when useful.</p>
+<p class="lead">Wingthing is a local-first, agent-first manager for durable agent runs and terminals. Start with local stdio MCP, then add another machine or a human display only when the task requires one.</p>
 
 <div class="docs-section" id="quickstart">
 <h2>quickstart</h2>
 
-<h3 style="font-size:14px;margin:16px 0 8px;color:var(--text)">give Codex or Claude access to local agents</h3>
+<h3 data-route="local-agent" style="font-size:14px;margin:16px 0 8px;color:var(--text)">1. give Codex or Claude local stdio MCP control</h3>
 <div class="docs-code">
 <span class="prompt">$ </span><span class="cmd">curl -fsSL https://wingthing.ai/install.sh | sh</span><br>
 <br>
@@ -69,49 +69,52 @@
 <span class="comment"># Claude Code</span><br>
 <span class="prompt">$ </span><span class="cmd">claude mcp add --scope user wingthing -- wt mcp stdio --client claude</span>
 </div>
-<p>Restart the client, then ask it to call <code>wingthing_capabilities</code>. It can start persistent terminals or headless runs, wait for results, steer work, and stop it.</p>
+<p>Restart the client, then ask it to call <code>wingthing_capabilities</code>. Child agents use existing project directories and the current OS user's existing provider logins on this computer. No Wingthing account or daemon is required.</p>
 
-<h3 style="font-size:14px;margin:16px 0 8px;color:var(--text)">run your own private browser portal</h3>
+<h3 data-route="local-human" style="font-size:14px;margin:16px 0 8px;color:var(--text)">2. start a local sandboxed agent terminal yourself</h3>
 <div class="docs-code">
-<span class="prompt">$ </span><span class="cmd">wt roost start --https</span><span class="comment"> # portal + gateway + local wing</span><br>
-<span class="prompt">$ </span><span class="cmd">open https://localhost:8443</span>
+<span class="prompt">$ </span><span class="cmd">cd /path/to/existing/project</span><br>
+<span class="prompt">$ </span><span class="cmd">wt egg claude --name work</span><br>
+<span class="prompt">$ </span><span class="cmd">wt attach work</span>
 </div>
-<p>This self-hosted path needs no Wingthing account. WT creates a localhost-only certificate on demand, installs only its public CA for your current user, and keeps its private keys on this machine.</p>
+<p>The provider CLI must already be installed and authenticated locally. <code>wt egg</code> applies the project sandbox and keeps the terminal attachable without an account or daemon.</p>
 
-<h3 style="font-size:14px;margin:16px 0 8px;color:var(--text)">give an agent access to all your remote wings</h3>
-<p>On every execution machine, install and authenticate the provider CLIs that may run there, then log in and start its wing:</p>
+<h3 data-route="direct-remote" style="font-size:14px;margin:16px 0 8px;color:var(--text)">3. use direct remote MCP when machines differ</h3>
+<p>On every execution machine, keep the required workspace there, install and authenticate the provider CLIs that may run there, then log in and start its wing:</p>
 <div class="docs-code">
 <span class="prompt">$ </span><span class="cmd">wt login</span><br>
 <span class="prompt">$ </span><span class="cmd">wt start</span><br>
 </div>
-<p>On the parent-agent machine, log in to the same account and register the direct connector. If that machine is also an execution wing, it is already logged in:</p>
+<p>On the parent/connector machine, log in with an account authorized to access those wings so <code>wt mcp connect</code> can load its connector token, then register the direct connector:</p>
 <div class="docs-code">
 <span class="prompt">$ </span><span class="cmd">wt login</span><br>
 <span class="prompt">$ </span><span class="cmd">codex mcp add wingthing -- wt mcp connect --client codex</span><br>
 <span class="comment"># or: claude mcp add --scope user wingthing -- wt mcp connect --client claude</span>
 </div>
-<p>The agent calls <code>wing_list</code>, then passes an explicit <code>wing_id</code> to every operation. The hosted service supplies the access-filtered directory and WebRTC signaling; MCP payloads travel directly between the connector and selected wing. The first release expects the peers to share a LAN or tailnet unless you configure STUN or TURN under <code>ice_servers</code> in <code>~/.wingthing/wing.yaml</code>; the several-computer pattern includes the exact YAML shape.</p>
+<p>Run <code>wt start</code> on the parent only when that machine also executes agents.</p>
+<p>The agent calls <code>wing_list</code>, then passes an explicit <code>wing_id</code> to every operation. The hosted service supplies identity, the access-filtered directory, and WebRTC signaling; MCP payloads travel directly between the connector and selected wing. The connector never silently changes to hosted relay. The first release expects the peers to share a LAN or tailnet unless you configure STUN or TURN under <code>ice_servers</code> in <code>~/.wingthing/wing.yaml</code>; the several-computer pattern includes the exact YAML shape.</p>
 
-<h3 style="font-size:14px;margin:16px 0 8px;color:var(--text)">use the durable terminal yourself</h3>
+<h3 data-route="self-hosted-browser" style="font-size:14px;margin:16px 0 8px;color:var(--text)">4. self-host first when a person needs a browser</h3>
 <div class="docs-code">
-<span class="prompt">$ </span><span class="cmd">wt terminal --name work</span><br>
-<span class="prompt">$ </span><span class="cmd">wt attach work</span>
+<span class="prompt">$ </span><span class="cmd">wt roost start --https</span><span class="comment"> # portal + gateway + local wing</span><br>
+<span class="prompt">$ </span><span class="cmd">open https://localhost:8443</span>
 </div>
+<p>This self-hosted route needs no Wingthing account or hosted-relay entitlement. WT creates a localhost-only certificate on demand, installs only its public CA for your current user, and keeps its private keys on this machine. Use the localhost-plus-SSH pattern for a remote wing, or configure OAuth, HTTPS, and explicit enrollment for several people.</p>
 
-<h3 style="font-size:14px;margin:16px 0 8px;color:var(--text)">optional hosted portal</h3>
+<h3 data-route="hosted-relay" style="font-size:14px;margin:16px 0 8px;color:var(--text)">5. use the entitled hosted browser only if needed</h3>
 <div class="docs-code">
 <span class="prompt">$ </span><span class="cmd">wt login</span><br>
 <span class="prompt">$ </span><span class="cmd">wt start</span><br>
 <span class="prompt">$ </span><span class="cmd">open https://app.wingthing.ai</span>
 </div>
-<p>Free accounts see wing readiness and direct-agent setup in the portal. Accounts with hosted relay access can also start and resume browser terminals. The public direct-free service does not let an account grant itself relay access; Pro and team relay entitlements are provisioned separately.</p>
+<p>The optional hosted browser terminal requires an account with hosted-relay access and a selected wing whose effective policy is <code>hosted_relay: allow</code>. The public direct-free service does not let an account grant itself relay access. In this mode, the service relays application-encrypted terminal and control payloads, sees routing metadata, and supplies the browser code.</p>
 
-<p>Your machine is a <strong>wing</strong>, the runtime that owns the processes and workspaces. An LLM manages it through MCP; a person can use the same runtime through the CLI or browser. The hosted service coordinates direct connections by default. Pro includes its encrypted browser-terminal and control relay; the native connector never silently changes from direct transport to relay transport.</p>
+<p>Your machine is a <strong>wing</strong>, the runtime that owns its processes, workspaces, agent homes, sessions, and runs. Local and remote adapters address that runtime; neither a connector nor a browser moves execution off the selected wing.</p>
 </div>
 
 <div class="docs-section" id="overview">
 <h2>overview</h2>
-<p>wingthing runs Claude Code, Codex, Ollama, and other AI agents behind one local control plane. The interface can be a CLI, browser, or MCP client. Execution stays on the wing where the selected workspace and hardware live.</p>
+<p>Wingthing runs Claude Code, Codex, Ollama, and other agents behind one wing-owned control plane. Local stdio MCP is the primary agent interface. The local CLI is the primary human terminal. Direct remote MCP connects different machines. A self-hosted roost adds browser visibility; the entitled hosted relay is an optional alternative. Execution stays on the wing where the selected workspace, provider login, and hardware live.</p>
 <table class="vocab-table">
 <tr><th>term</th><th>what it is</th></tr>
 <tr><td>portal</td><td>The inventory and controls presented to a person or LLM. The browser and MCP are portal adapters, though they do not yet expose every object with full parity.</td></tr>
@@ -160,13 +163,13 @@
 
 <div class="docs-section" id="wing-setup">
 <h2>wing setup</h2>
-<p>Three commands to go from install to remote access:</p>
+<p>Remote execution through direct MCP or the hosted browser needs a running wing. Local stdio MCP, local terminal commands, and an embedded self-hosted roost do not require a separate wing daemon. Prepare each standalone execution wing from a terminal:</p>
 <div class="docs-code">
-<span class="prompt">$ </span><span class="cmd">wt login</span><span class="comment">                  # authenticate with the hosted portal</span><br>
-<span class="prompt">$ </span><span class="cmd">wt start</span><span class="comment">                  # start the wing daemon</span><br>
-<span class="prompt">$ </span><span class="cmd">open https://app.wingthing.ai</span><span class="comment"> # wing readiness and direct setup</span>
+<span class="prompt">$ </span><span class="cmd">wt login</span><span class="comment">       # authenticate for identity, directory, and signaling</span><br>
+<span class="prompt">$ </span><span class="cmd">wt start</span><span class="comment">       # start the execution wing</span><br>
+<span class="prompt">$ </span><span class="cmd">wt wing status</span><span class="comment"> # verify it is ready</span>
 </div>
-<p><code>wt start</code> runs the wing as a background daemon. Hosted accounts with relay access also get browser terminal controls; direct-only free accounts get the native connector instructions instead. Use <code>wt wing start --foreground</code> for debugging.</p>
+<p><code>wt start</code> runs the wing as a background daemon. Register <code>wt mcp connect</code> on the parent-agent machine for direct control. Opening the hosted app is unnecessary for that path. Use <code>wt wing start --foreground</code> for debugging.</p>
 <p>Other wing commands:</p>
 <div class="docs-code">
 <span class="prompt">$ </span><span class="cmd">wt wing status</span><span class="comment">            # check daemon status + active sessions</span><br>

--- a/internal/relay/templates/docs.html
+++ b/internal/relay/templates/docs.html
@@ -79,6 +79,12 @@
 <p>This self-hosted path needs no Wingthing account. WT creates a localhost-only certificate on demand, installs only its public CA for your current user, and keeps its private keys on this machine.</p>
 
 <h3 style="font-size:14px;margin:16px 0 8px;color:var(--text)">give an agent access to all your remote wings</h3>
+<p>On every execution machine, install and authenticate the provider CLIs that may run there, then log in and start its wing:</p>
+<div class="docs-code">
+<span class="prompt">$ </span><span class="cmd">wt login</span><br>
+<span class="prompt">$ </span><span class="cmd">wt start</span><br>
+</div>
+<p>On the parent-agent machine, log in to the same account and register the direct connector. If that machine is also an execution wing, it is already logged in:</p>
 <div class="docs-code">
 <span class="prompt">$ </span><span class="cmd">wt login</span><br>
 <span class="prompt">$ </span><span class="cmd">codex mcp add wingthing -- wt mcp connect --client codex</span><br>

--- a/internal/relay/templates/home.html
+++ b/internal/relay/templates/home.html
@@ -3,7 +3,14 @@
 <style>
 .hero{padding:40px 0 24px;text-align:center}
 .hero h1{font-size:28px;font-weight:700;letter-spacing:-0.03em;margin-bottom:8px}
-.hero .tagline{color:var(--text-dim);font-size:15px;line-height:1.5;max-width:480px;margin:0 auto 24px}
+.hero .tagline{color:var(--text-dim);font-size:15px;line-height:1.6;max-width:720px;margin:0 auto 24px}
+.route-map{max-width:900px;margin:0 auto 22px;text-align:left;display:grid;gap:8px}
+.route-map a{display:grid;grid-template-columns:34px 220px 1fr;gap:12px;align-items:baseline;background:var(--bg-card);border:1px solid var(--accent);border-radius:6px;padding:10px 14px;text-decoration:none;color:var(--text)}
+.route-map a:hover{border-color:var(--action)}
+.route-num{font-family:var(--mono);font-size:11px;color:var(--action)}
+.route-title{font-weight:600;font-size:13px}
+.route-detail{font-size:12px;color:var(--text-dim)}
+.route-detail code{color:var(--text)}
 .prompt-flow{font-family:var(--mono);font-size:18px;margin-top:8px}
 .prompt-line{display:flex;align-items:center;justify-content:center;gap:6px;padding:8px 0}
 .prompt-dim{color:var(--text-dim)}
@@ -74,6 +81,8 @@ a.prompt-line:hover .prompt-key{background:var(--action);color:#fff}
 .sb-tip{font-family:var(--mono);font-size:11px;color:var(--text-dim);line-height:1.6;margin-top:12px;padding:0 4px}
 @media(max-width:700px){
   .hero h1{font-size:22px}
+  .route-map a{grid-template-columns:28px 1fr;gap:4px 8px}
+  .route-detail{grid-column:2}
   .how-grid{grid-template-columns:1fr}
   .sb-layout{grid-template-columns:1fr}
   .install{font-size:11px;padding:12px 14px}
@@ -92,19 +101,26 @@ a.prompt-line:hover .prompt-key{background:var(--action);color:#fff}
         if(e.key==='.'&&!e.ctrlKey&&!e.metaKey&&!e.altKey){
             e.preventDefault();
             var app=document.getElementById('prompt-app');
-            window.location.href=app?app.href:'/login';
+            window.location.href=app?app.href:'/install';
         }
     });
 })();
 </script>
 <div class="hero">
-<h1>durable agent runs and terminals</h1>
-<p class="tagline">Wingthing is a typed agent manager for Codex, Claude, and other agents. Start and supervise work on the wing where the code and credentials already live, then take over a persistent terminal when a person belongs in the loop.</p>
+<h1>local-first control for coding agents</h1>
+<p class="tagline">Give an agent typed control of local agents on the code and provider login already on this machine. Move to direct remote MCP only when execution moves to another machine, and add a browser only when a person needs one.</p>
+<div class="route-map" aria-label="Wingthing setup routes">
+<a href="/patterns/local-subagents/INSTRUCTIONS.md" data-route="local-agent"><span class="route-num">01</span><span class="route-title">agent controls local agents</span><span class="route-detail"><code>wt mcp stdio</code> · no account or daemon</span></a>
+<a href="/patterns/local-sandbox/INSTRUCTIONS.md" data-route="local-human"><span class="route-num">02</span><span class="route-title">person starts a local agent terminal</span><span class="route-detail"><code>wt egg</code> · sandboxed and attachable</span></a>
+<a href="/patterns/remote-orchestration/INSTRUCTIONS.md" data-route="direct-remote"><span class="route-num">03</span><span class="route-title">machines differ</span><span class="route-detail"><code>wt mcp connect</code> · direct remote MCP to an explicit wing</span></a>
+<a href="/patterns/personal-remote-wing/INSTRUCTIONS.md" data-route="self-hosted-browser"><span class="route-num">04</span><span class="route-title">person needs a browser</span><span class="route-detail"><code>wt serve --local --https</code> · self-host first</span></a>
+<a href="/patterns/hosted-browser-wing/INSTRUCTIONS.md" data-route="hosted-relay"><span class="route-num">05</span><span class="route-title">optional hosted browser</span><span class="route-detail">requires hosted-relay entitlement and an allowing wing</span></a>
+</div>
 {{if .User}}<div class="prompt-flow">
-<a href="{{.AppURL}}" class="prompt-line" id="prompt-app"><span class="prompt-dim">press</span> <span class="prompt-key">.</span> <span class="prompt-dim">to</span> <span class="prompt-key">open app</span></a>
+<a href="{{.AppURL}}" class="prompt-line" id="prompt-app"><span class="prompt-dim">press</span> <span class="prompt-key">.</span> <span class="prompt-dim">to</span> <span class="prompt-key">open optional hosted app</span></a>
 </div>
 {{else}}<div class="prompt-flow" id="prompt-flow">
-<div class="prompt-line"><span class="prompt-dim">press</span> <span class="prompt-key">.</span> <span class="prompt-dim">to start</span></div>
+<a href="/install" class="prompt-line" id="prompt-app"><span class="prompt-dim">press</span> <span class="prompt-key">.</span> <span class="prompt-dim">to</span> <span class="prompt-key">install locally</span></a>
 </div>{{end}}
 {{if .HeroVideo}}<div class="hero-video" onclick="(function(){var v=document.getElementById('hero-vid');if(v.requestFullscreen)v.requestFullscreen();else if(v.webkitRequestFullscreen)v.webkitRequestFullscreen()})()"><video id="hero-vid" src="/hero.mp4" autoplay muted loop playsinline onloadedmetadata="this.playbackRate=0.8"></video><button class="hero-fs"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 3H5a2 2 0 00-2 2v3m18 0V5a2 2 0 00-2-2h-3m0 18h3a2 2 0 002-2v-3M3 16v3a2 2 0 002 2h3"/></svg></button></div>{{end}}
 </div>
@@ -113,11 +129,11 @@ a.prompt-line:hover .prompt-key{background:var(--action);color:#fff}
 <button onclick="switchTab('sb')">sandbox builder</button>
 </div>
 <div id="tab-how" class="how">
-<h2>how it works</h2>
+<h2>one wing owns each run</h2>
 <div class="how-grid">
 <div class="how-card">
 <h3>portal</h3>
-<p>The unified inventory and controls for your agents. An LLM uses typed MCP operations; a person can inspect or take over the same sessions.</p>
+<p>An agent starts with the local stdio MCP portal. A person uses the CLI, or adds a self-hosted browser when visibility requires one.</p>
 </div>
 <div class="how-card">
 <h3>wing</h3>
@@ -139,19 +155,19 @@ a.prompt-line:hover .prompt-key{background:var(--action);color:#fff}
 </div>
 <div class="how-card">
 <h3>direct by default</h3>
-<p>The hosted service coordinates identity, wing discovery, keys, and connection setup. Free agent clients send MCP payloads directly to their wing; the hosted encrypted terminal and control relay is a Pro feature.</p>
+<p>When machines differ, <code>wt mcp connect</code> selects a wing explicitly and sends MCP payloads directly to it. It never falls back to hosted relay.</p>
 </div>
 <div class="how-card">
 <h3>self-hostable</h3>
-<p><code>wt roost start --https</code> runs a portal, gateway, and embedded wing on your machine. WT creates a localhost-only certificate on demand, installs only its public CA for your user, and keeps the private key on this machine. No hosted account needed.</p>
+<p><code>wt roost start --https</code> is the first browser route: a portal, gateway, and embedded wing on your machine. No hosted account or relay entitlement is needed.</p>
 </div>
 <div class="how-card">
 <h3>any agent</h3>
 <p><code>wt egg claude</code>, <code>wt egg codex</code>, <code>wt egg gemini</code>. Switch the provider, keep the execution contract and sandbox config.</p>
 </div>
 <div class="how-card">
-<h3>passkey auth</h3>
-<p>WebAuthn passkeys. One-time challenges and signature verification happen on your wing against a locally pinned public key.</p>
+<h3>hosted relay is optional</h3>
+<p>The <code>wingthing.ai</code> browser relay is available only when the account is entitled and the selected wing allows it. The hosted service does not run agents.</p>
 </div>
 </div>
 </div>
@@ -206,6 +222,7 @@ a.prompt-line:hover .prompt-key{background:var(--action);color:#fff}
 </div>
 </div>
 <div class="links">
+<a href="/patterns">choose a route</a>
 <a href="/docs">docs</a>
 <a href="https://github.com/ehrlich-b/wingthing">github</a>
 </div>

--- a/internal/relay/templates/home.html
+++ b/internal/relay/templates/home.html
@@ -211,14 +211,8 @@ a.prompt-line:hover .prompt-key{background:var(--action);color:#fff}
 </div>
 <script>
 (function(){
-var agents=['claude','codex','cursor','ollama','gemini'];
-var profiles={
-  claude:{env:['ANTHROPIC_API_KEY'],writeDirs:['~/.cache/claude/'],writeRegex:['~/.claude*'],domains:['*.anthropic.com','*.claude.com','sentry.io','statsigapi.net']},
-  codex:{env:['OPENAI_API_KEY'],writeDirs:['~/.codex/'],writeRegex:[],domains:['api.openai.com','*.openai.com']},
-  cursor:{env:['ANTHROPIC_API_KEY','OPENAI_API_KEY'],writeDirs:['~/.cursor/','~/Library/Caches/cursor-compile-cache/'],writeRegex:[],domains:['api.anthropic.com','api.openai.com','*.cursor.sh']},
-  ollama:{env:[],writeDirs:['~/.ollama/'],writeRegex:[],domains:['localhost']},
-  gemini:{env:['GEMINI_API_KEY','GOOGLE_API_KEY'],writeDirs:['~/.gemini/'],writeRegex:[],domains:['*.googleapis.com','generativelanguage.googleapis.com']}
-};
+var agents={{.SandboxBuilderAgents}};
+var profiles={{.SandboxBuilderAgentProfiles}};
 var defaultFS=[
   {mode:'rw',path:'./'},
   {mode:'rw',path:'~/.cache/'},
@@ -374,6 +368,14 @@ window.sbAddEnv=function(){state.envAllow.push('');renderEnv();sbRender();};
 
 function esc(s){return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');}
 function rpad(s,n){while(s.length<n)s+=' ';return s;}
+function agentPath(d,regex){return '~/'+d+(regex?'*':'/');}
+function agentEnv(ap){
+  var env=[],seen={};
+  (ap.EnvVars||[]).concat(ap.PlatformEnv||[],Object.keys(ap.SetEnv||{})).forEach(function(e){
+    if(!seen[e]){seen[e]=true;env.push(e);}
+  });
+  return env;
+}
 
 window.sbRender=function(){
   state.baseFS=document.getElementById('sb-base-fs').checked;
@@ -456,11 +458,11 @@ window.sbRender=function(){
     });
     // Agent write dirs
     if(ap){
-      ap.writeDirs.forEach(function(d){
-        pv.push({text:rpad('  - "rw:'+d+'"',38)+'# ['+state.agent+']',cls:'y-agent'});
+      (ap.WriteDirs||[]).forEach(function(d){
+        pv.push({text:rpad('  - "rw:'+agentPath(d,false)+'"',38)+'# ['+state.agent+']',cls:'y-agent'});
       });
-      ap.writeRegex.forEach(function(d){
-        pv.push({text:rpad('  - "rw:'+d+'"',38)+'# ['+state.agent+'] (regex)',cls:'y-agent'});
+      (ap.WriteRegex||[]).forEach(function(d){
+        pv.push({text:rpad('  - "rw:'+agentPath(d,true)+'"',38)+'# ['+state.agent+'] (regex)',cls:'y-agent'});
       });
     }
     // Base deny rules (skip overridden by user rw/ro)
@@ -479,11 +481,11 @@ window.sbRender=function(){
     if(showFS){
       pv.push({text:'fs:',cls:userFS.length?'y-user':'y-agent'});
       if(ap){
-        ap.writeDirs.forEach(function(d){
-          pv.push({text:rpad('  - "rw:'+d+'"',38)+'# ['+state.agent+']',cls:'y-agent'});
+        (ap.WriteDirs||[]).forEach(function(d){
+          pv.push({text:rpad('  - "rw:'+agentPath(d,false)+'"',38)+'# ['+state.agent+']',cls:'y-agent'});
         });
-        ap.writeRegex.forEach(function(d){
-          pv.push({text:rpad('  - "rw:'+d+'"',38)+'# ['+state.agent+'] (regex)',cls:'y-agent'});
+        (ap.WriteRegex||[]).forEach(function(d){
+          pv.push({text:rpad('  - "rw:'+agentPath(d,true)+'"',38)+'# ['+state.agent+'] (regex)',cls:'y-agent'});
         });
       }
       userFS.forEach(function(r){
@@ -493,7 +495,7 @@ window.sbRender=function(){
   }
 
   // --- Network section ---
-  var agentNet=ap?ap.domains:[];
+  var agentNet=ap?(ap.Domains||[]):[];
   if(state.netMode==='*'){
     pv.push({text:'network: "*"',cls:'y-user'});
   }else if(state.netMode==='domains'){
@@ -520,13 +522,13 @@ window.sbRender=function(){
   }
 
   // --- Env section ---
-  var agentEnv=ap?ap.env:[];
+  var agentEnvVars=ap?agentEnv(ap):[];
   var userEnv=state.envAllow.filter(function(e){return e;});
   if(state.envAll){
     pv.push({text:'env: "*"',cls:'y-user'});
-  }else if(agentEnv.length||userEnv.length){
+  }else if(agentEnvVars.length||userEnv.length){
     pv.push({text:'env:',cls:userEnv.length?'y-user':'y-agent'});
-    agentEnv.forEach(function(e){
+    agentEnvVars.forEach(function(e){
       pv.push({text:rpad('  - "'+e+'"',38)+'# ['+state.agent+']',cls:'y-agent'});
     });
     userEnv.forEach(function(e){

--- a/internal/relay/templates/install.html
+++ b/internal/relay/templates/install.html
@@ -31,7 +31,7 @@
 {{define "content"}}
 <div class="inst-hero">
 <h1>install wt</h1>
-<p>Install Wingthing, the typed agent manager for durable agent runs and terminals. macOS and Linux, x64 and arm64.</p>
+<p>Install Wingthing for local typed agent control first. Add a wing daemon, remote connector, or browser portal only when the work crosses those boundaries. macOS and Linux, x64 and arm64.</p>
 </div>
 
 <div class="inst-platforms">
@@ -50,40 +50,53 @@
 
 <div class="inst-section">
 <h2>get started</h2>
-<p>Every launch uses an existing workspace and provider login on its execution wing. Wingthing keeps task and terminal state on that wing; it does not copy the workspace, credentials, or durable memory elsewhere.</p>
+<p>Every launch uses an existing workspace and provider login on its execution wing. Wingthing keeps task and terminal state there; it does not copy code, credentials, or durable memory to another machine.</p>
 <ol class="inst-steps">
-<li>
-<h3>start an agent terminal locally</h3>
-<p>Authenticate the provider CLI first and use an existing project directory. No Wingthing account or daemon is required. Detach with <code>Ctrl+B</code>, then <code>Q</code>.</p>
+<li data-route="local-agent">
+<h3>give a parent agent typed local control</h3>
+<p>Register local stdio MCP, restart the parent client, and ask it to call <code>wingthing_capabilities</code>. Child agents use the existing code and provider login on this computer. No Wingthing account or daemon is required.</p>
+<div class="inst-code">
+<span class="prompt">$ </span><span class="cmd">codex mcp add wingthing -- wt mcp stdio --client codex</span><br>
+<span class="comment"># or: claude mcp add --scope user wingthing -- wt mcp stdio --client claude</span>
+</div>
+</li>
+<li data-route="local-human">
+<h3>start a local sandboxed agent terminal yourself</h3>
+<p>Authenticate the provider CLI first and use an existing project directory. Detach with <code>Ctrl+B</code>, then <code>Q</code>.</p>
 <div class="inst-code">
 <span class="prompt">$ </span><span class="cmd">cd /path/to/existing/project</span><br>
 <span class="prompt">$ </span><span class="cmd">wt egg claude --name work</span><br>
 <span class="prompt">$ </span><span class="cmd">wt attach work</span>
 </div>
 </li>
-<li>
-<h3>give a parent agent typed local control</h3>
-<p>Register local MCP, restart the parent client, and ask it to call <code>wingthing_capabilities</code>. Use <code>agent_run</code> for a semantic result or <code>agent_start</code> for an attachable PTY.</p>
+<li data-route="direct-remote">
+<h3>use direct remote MCP when machines differ</h3>
+<p>On each execution wing, run <code>wt login</code>, make sure the wing is authorized for the connector account personally or through an organization, then run <code>wt start</code>. Calls go directly to an explicit wing and never silently fall back to hosted relay.</p>
 <div class="inst-code">
-<span class="prompt">$ </span><span class="cmd">codex mcp add wingthing -- wt mcp stdio --client codex</span><br>
-<span class="comment"># or: claude mcp add --scope user wingthing -- wt mcp stdio --client claude</span>
+<span class="prompt">$ </span><span class="cmd">wt login</span><br>
+<span class="prompt">$ </span><span class="cmd">wt start</span>
+</div>
+<p>Separately, run <code>wt login</code> on the parent/connector machine so <code>wt mcp connect</code> can load its connector token, then register it with the parent client. Run <code>wt start</code> on the parent only when that machine also executes agents.</p>
+<div class="inst-code">
+<span class="prompt">$ </span><span class="cmd">wt login</span><br>
+<span class="prompt">$ </span><span class="cmd">codex mcp add wingthing -- wt mcp connect --client codex</span>
 </div>
 </li>
-<li>
-<h3>optionally run your own browser portal</h3>
-<p>No Wingthing account is required. This creates and trusts a localhost-only certificate for your current user; Linux needs <code>certutil</code> from <code>libnss3-tools</code> or <code>nss-tools</code> for that trust step.</p>
+<li data-route="self-hosted-browser">
+<h3>self-host first when a person needs a browser</h3>
+<p>No Wingthing account or hosted-relay entitlement is required. This creates and trusts a localhost-only certificate for your current user; Linux needs <code>certutil</code> from <code>libnss3-tools</code> or <code>nss-tools</code> for that trust step.</p>
 <div class="inst-code">
 <span class="prompt">$ </span><span class="cmd">wt roost start --https</span><br>
 <span class="prompt">$ </span><span class="cmd">open https://localhost:8443</span>
 </div>
 </li>
-<li>
-<h3>optionally connect a parent agent to remote wings</h3>
-<p>Run <code>wt login</code> and <code>wt start</code> on every execution machine, then register <code>wt mcp connect</code> with the parent Claude or Codex client. Free MCP payloads travel directly to the selected wing; the hosted browser terminal and control relay require relay access.</p>
+<li data-route="hosted-relay">
+<h3>use the entitled hosted browser only if needed</h3>
+<p>For this route, the hosted browser terminal and control relay require relay access on the account and <code>hosted_relay: allow</code> on the selected wing. This optional path is separate from direct remote MCP.</p>
 <div class="inst-code">
 <span class="prompt">$ </span><span class="cmd">wt login</span><br>
 <span class="prompt">$ </span><span class="cmd">wt start</span><br>
-<span class="prompt">$ </span><span class="cmd">codex mcp add wingthing -- wt mcp connect --client codex</span>
+<span class="prompt">$ </span><span class="cmd">open https://app.wingthing.ai</span>
 </div>
 </li>
 </ol>
@@ -99,6 +112,6 @@
 <div class="inst-code">
 <span class="prompt">$ </span><span class="cmd">wt update</span>
 </div>
-<p>Downloads the latest release and restarts the wing daemon if running. You can also trigger updates remotely from the web dashboard.</p>
+<p>Downloads the latest release and restarts the local wing daemon if it is running.</p>
 </div>
 {{end}}

--- a/internal/relay/templates/patterns.html
+++ b/internal/relay/templates/patterns.html
@@ -72,6 +72,19 @@
 
 <section class="pattern">
 <div class="pattern-num">04</div>
+<div class="pattern-tags"><span class="pattern-tag">remote computer</span><span class="pattern-tag">browser</span><span class="pattern-tag">hosted relay</span></div>
+<h2>Use the hosted browser on a remote wing</h2>
+<p>Start and resume a persistent agent terminal from <code>app.wingthing.ai</code> when your account and wing both permit hosted relay.</p>
+<ul class="pattern-facts">
+<li><strong>You need:</strong> an account with hosted-relay access; an execution machine running <code>wt login</code> and <code>wt start</code>; the provider already authenticated there; and effective wing policy <code>hosted_relay: allow</code>.</li>
+<li><strong>You get:</strong> a hosted browser terminal whose application-encrypted payloads are relayed to the selected wing. The hosted service still sees routing metadata and supplies the browser code.</li>
+</ul>
+<div class="flow">hosted browser -> encrypted relay -> selected wing -> agent</div>
+<div class="recipe-row"><a href="/patterns/hosted-browser-wing/INSTRUCTIONS.md">read setup guide</a><button class="copy-recipe" data-copy="/patterns/hosted-browser-wing/INSTRUCTIONS.md">copy setup guide</button></div>
+</section>
+
+<section class="pattern">
+<div class="pattern-num">05</div>
 <div class="pattern-tags"><span class="pattern-tag">remote computer</span><span class="pattern-tag">browser</span><span class="pattern-tag">self-hosted</span></div>
 <h2>Control a remote agent from a localhost browser</h2>
 <p>Run the web app on the computer in front of you, carry it over SSH, and launch Claude or Codex on the remote computer.</p>
@@ -84,7 +97,7 @@
 </section>
 
 <section class="pattern">
-<div class="pattern-num">05</div>
+<div class="pattern-num">06</div>
 <div class="pattern-tags"><span class="pattern-tag">team</span><span class="pattern-tag">private server</span><span class="pattern-tag">browser</span></div>
 <h2>Give a team a private browser-based agent host</h2>
 <p>Run Wingthing on one shared server so several people can launch and resume their own agent sessions through a private web UI.</p>
@@ -97,7 +110,7 @@
 </section>
 
 <section class="pattern">
-<div class="pattern-num">06</div>
+<div class="pattern-num">07</div>
 <div class="pattern-tags"><span class="pattern-tag">private server</span><span class="pattern-tag">AI-driven</span></div>
 <h2>Let an AI control agents on your private roost</h2>
 <p>Connect a local Claude or Codex client to your self-hosted Wingthing server and let it manage work there.</p>

--- a/internal/relay/templates/patterns.html
+++ b/internal/relay/templates/patterns.html
@@ -25,101 +25,102 @@
 {{end}}
 {{define "content"}}
 <main class="patterns">
-<h1>choose a durable agent workflow</h1>
-<p class="lead">Wingthing is a typed agent manager for durable agent runs and terminals. Each setup below works today; pick one to see exactly what must be installed, where execution and state live, and how the driver connects.</p>
+<h1>choose the smallest route</h1>
+<p class="lead">Start with local stdio MCP when an agent is driving, or a local sandboxed terminal when a person is driving. If machines differ, use direct remote MCP. If a person needs a browser, self-host a roost first. The hosted browser relay is the last, optional route and requires entitlement.</p>
 
-<div class="plain-language"><strong>A wing is the computer that runs the work.</strong> Before launch, choose the execution wing, an existing workspace on it, a headless or terminal display, the owner whose provider home supplies credentials, and the wing that keeps durable state. Wingthing routes control; it does not copy workspaces, credentials, provider history, or Wingthing memory between wings.</div>
+<div class="plain-language"><strong>Code, credentials, processes, and durable state stay on the execution wing.</strong> Wingthing routes control to an existing workspace; it does not copy workspaces, provider logins, provider history, or Wingthing memory between machines.</div>
 
 <div class="pattern-list">
-<section class="pattern">
+<section class="pattern" data-route="local-agent">
 <div class="pattern-num">01</div>
-<div class="pattern-tags"><span class="pattern-tag">one computer</span><span class="pattern-tag">human-driven</span></div>
-<h2>Run a durable, sandboxed agent on this computer</h2>
-<p>Start Claude, Codex, or another agent in a project without setting up a server or account.</p>
-<ul class="pattern-facts">
-<li><strong>You need:</strong> Wingthing and the agent CLI installed locally.</li>
-<li><strong>You get:</strong> project sandbox policy, a persistent terminal, and the ability to disconnect and reattach later.</li>
-</ul>
-<div class="flow">project folder -> sandboxed agent -> reattach later</div>
-<div class="recipe-row"><a href="/patterns/local-sandbox/INSTRUCTIONS.md">read setup guide</a><button class="copy-recipe" data-copy="/patterns/local-sandbox/INSTRUCTIONS.md">copy setup guide</button></div>
-</section>
-
-<section class="pattern">
-<div class="pattern-num">02</div>
-<div class="pattern-tags"><span class="pattern-tag">one computer</span><span class="pattern-tag">AI-driven</span></div>
+<div class="pattern-tags"><span class="pattern-tag">one computer</span><span class="pattern-tag">agent-driven</span><span class="pattern-tag">stdio MCP</span></div>
 <h2>Let your current AI launch local sub-agents</h2>
-<p>Give a parent Claude or Codex session tools for delegating parts of a larger task to other agents on the same computer.</p>
+<p>Give a parent Claude or Codex session typed tools for agents on the same computer, using the code and provider logins already there.</p>
 <ul class="pattern-facts">
-<li><strong>You need:</strong> Wingthing added as a local MCP server in the parent AI client.</li>
-<li><strong>You get:</strong> start, wait, inspect, steer, and stop controls for sandboxed child agents.</li>
+<li><strong>You need:</strong> Wingthing registered as <code>wt mcp stdio</code> in the parent client. No account or daemon is required.</li>
+<li><strong>You get:</strong> typed start, wait, inspect, steer, and stop controls for local sandboxed child agents.</li>
 </ul>
-<div class="flow">parent AI -> Wingthing -> child agents on this computer</div>
+<div class="flow">parent AI -> local stdio MCP -> local child agents</div>
 <div class="recipe-row"><a href="/patterns/local-subagents/INSTRUCTIONS.md">read setup guide</a><button class="copy-recipe" data-copy="/patterns/local-subagents/INSTRUCTIONS.md">copy setup guide</button></div>
 </section>
 
-<section class="pattern">
+<section class="pattern" data-route="local-human">
+<div class="pattern-num">02</div>
+<div class="pattern-tags"><span class="pattern-tag">one computer</span><span class="pattern-tag">human-driven</span><span class="pattern-tag">terminal</span></div>
+<h2>Run a durable, sandboxed agent on this computer</h2>
+<p>Start Claude, Codex, or another agent in a local project without setting up a server or account.</p>
+<ul class="pattern-facts">
+<li><strong>You need:</strong> Wingthing and the provider agent CLI installed and authenticated locally.</li>
+<li><strong>You get:</strong> project sandbox policy, a persistent terminal, and the ability to disconnect and reattach later.</li>
+</ul>
+<div class="flow">person -> local sandboxed agent terminal -> reattach later</div>
+<div class="recipe-row"><a href="/patterns/local-sandbox/INSTRUCTIONS.md">read setup guide</a><button class="copy-recipe" data-copy="/patterns/local-sandbox/INSTRUCTIONS.md">copy setup guide</button></div>
+</section>
+
+<section class="pattern" data-route="direct-remote">
 <div class="pattern-num">03</div>
 <div class="pattern-tags"><span class="pattern-tag">several computers</span><span class="pattern-tag">AI-driven</span></div>
 <h2>Let one AI manage agents on several computers</h2>
-<p>Run agents on a home machine, office VM, or other host from one parent Claude or Codex session.</p>
+<p>When parent and execution machines differ, connect one Claude or Codex session directly to an explicitly selected wing.</p>
 <ul class="pattern-facts">
-<li><strong>You need:</strong> each computer logged into the same Wingthing account and running <code>wt start</code>; the parent AI uses <code>wt mcp connect</code>.</li>
-<li><strong>You get:</strong> one list of online computers, explicit machine selection, direct encrypted control, and durable remote work without inbound ports.</li>
+<li><strong>Each execution wing needs:</strong> its own <code>wt login</code>, authorization for the connector account (personal or organization), and a running <code>wt start</code>.</li>
+<li><strong>The parent/connector needs:</strong> its own <code>wt login</code> token and <code>wt mcp connect</code>. It runs <code>wt start</code> only when it also executes agents.</li>
+<li><strong>You get:</strong> direct encrypted MCP control without inbound ports or silent fallback to hosted relay.</li>
 </ul>
-<div class="flow">parent AI -> choose computer -> direct connection -> agent runs there</div>
+<div class="flow">parent AI -> direct remote MCP -> selected wing -> agent</div>
 <div class="recipe-row"><a href="/patterns/remote-orchestration/INSTRUCTIONS.md">read setup guide</a><button class="copy-recipe" data-copy="/patterns/remote-orchestration/INSTRUCTIONS.md">copy setup guide</button></div>
 </section>
 
-<section class="pattern">
+<section class="pattern" data-route="self-hosted-browser">
 <div class="pattern-num">04</div>
-<div class="pattern-tags"><span class="pattern-tag">remote computer</span><span class="pattern-tag">browser</span><span class="pattern-tag">hosted relay</span></div>
-<h2>Use the hosted browser on a remote wing</h2>
-<p>Start and resume a persistent agent terminal from <code>app.wingthing.ai</code> when your account and wing both permit hosted relay.</p>
-<ul class="pattern-facts">
-<li><strong>You need:</strong> an account with hosted-relay access; an execution machine running <code>wt login</code> and <code>wt start</code>; the provider already authenticated there; and effective wing policy <code>hosted_relay: allow</code>.</li>
-<li><strong>You get:</strong> a hosted browser terminal whose application-encrypted payloads are relayed to the selected wing. The hosted service still sees routing metadata and supplies the browser code.</li>
-</ul>
-<div class="flow">hosted browser -> encrypted relay -> selected wing -> agent</div>
-<div class="recipe-row"><a href="/patterns/hosted-browser-wing/INSTRUCTIONS.md">read setup guide</a><button class="copy-recipe" data-copy="/patterns/hosted-browser-wing/INSTRUCTIONS.md">copy setup guide</button></div>
-</section>
-
-<section class="pattern">
-<div class="pattern-num">05</div>
 <div class="pattern-tags"><span class="pattern-tag">remote computer</span><span class="pattern-tag">browser</span><span class="pattern-tag">self-hosted</span></div>
 <h2>Control a remote agent from a localhost browser</h2>
-<p>Run the web app on the computer in front of you, carry it over SSH, and launch Claude or Codex on the remote computer.</p>
+<p>When a person needs a browser, run the portal on the computer in front of them and carry the wing connection to the remote computer over SSH.</p>
 <ul class="pattern-facts">
-<li><strong>You need:</strong> Wingthing on both computers, SSH access to the remote computer, and the agent already logged in there.</li>
-<li><strong>You get:</strong> a private <code>https://localhost</code> page for starting and resuming durable sessions on the remote computer, without using the hosted relay. WT creates a localhost-only certificate on demand, installs only its public CA for your user, and keeps the private key on this computer.</li>
+<li><strong>You need:</strong> Wingthing on both computers, SSH access to the remote computer, and the provider agent already authenticated there.</li>
+<li><strong>You get:</strong> a private <code>https://localhost</code> browser for remote sessions without a Wingthing account or hosted relay.</li>
 </ul>
 <div class="flow">localhost browser -> local portal -> SSH tunnel -> remote wing -> agent</div>
 <div class="recipe-row"><a href="/patterns/personal-remote-wing/INSTRUCTIONS.md">read setup guide</a><button class="copy-recipe" data-copy="/patterns/personal-remote-wing/INSTRUCTIONS.md">copy setup guide</button></div>
 </section>
 
-<section class="pattern">
-<div class="pattern-num">06</div>
-<div class="pattern-tags"><span class="pattern-tag">team</span><span class="pattern-tag">private server</span><span class="pattern-tag">browser</span></div>
+<section class="pattern" data-route="self-hosted-team">
+<div class="pattern-num">05</div>
+<div class="pattern-tags"><span class="pattern-tag">team</span><span class="pattern-tag">private server</span><span class="pattern-tag">self-hosted browser</span></div>
 <h2>Give a team a private browser-based agent host</h2>
-<p>Run Wingthing on one shared server so several people can launch and resume their own agent sessions through a private web UI.</p>
+<p>Run one self-hosted roost so enrolled people can launch and resume their own agent sessions on a shared server.</p>
 <ul class="pattern-facts">
-<li><strong>You need:</strong> a server, HTTPS hostname, OAuth login, an exact email enrollment list, and project directories on that server.</li>
-<li><strong>You get:</strong> a self-hosted portal, per-user sessions, and separate per-user agent homes on the shared host.</li>
+<li><strong>You need:</strong> a server, HTTPS hostname, OAuth login, an exact email enrollment list, and existing project directories on that server.</li>
+<li><strong>You get:</strong> a private portal, per-user sessions, and separate per-user agent homes without a wingthing.ai relay entitlement.</li>
 </ul>
 <div class="flow">team browsers -> private roost -> agents on the shared server</div>
 <div class="recipe-row"><a href="/patterns/shared-web-roost/INSTRUCTIONS.md">read setup guide</a><button class="copy-recipe" data-copy="/patterns/shared-web-roost/INSTRUCTIONS.md">copy setup guide</button></div>
 </section>
 
-<section class="pattern">
-<div class="pattern-num">07</div>
-<div class="pattern-tags"><span class="pattern-tag">private server</span><span class="pattern-tag">AI-driven</span></div>
+<section class="pattern" data-route="self-hosted-agent">
+<div class="pattern-num">06</div>
+<div class="pattern-tags"><span class="pattern-tag">private server</span><span class="pattern-tag">AI-driven</span><span class="pattern-tag">self-hosted MCP</span></div>
 <h2>Let an AI control agents on your private roost</h2>
-<p>Connect a local Claude or Codex client to your self-hosted Wingthing server and let it manage work there.</p>
+<p>Connect Claude or Codex to the authenticated HTTP MCP endpoint of a self-hosted roost.</p>
 <ul class="pattern-facts">
-<li><strong>You need:</strong> an enrolled account on a roost with HTTPS and OAuth, plus its HTTP MCP endpoint added to the parent AI client.</li>
-<li><strong>You get:</strong> authenticated control of that user's agent runs and persistent sessions on the roost server.</li>
+<li><strong>You need:</strong> an enrolled account on a roost with HTTPS and OAuth, plus that endpoint added to the parent AI client.</li>
+<li><strong>You get:</strong> authenticated agent control of that user's runs and sessions on the roost's embedded wing.</li>
 </ul>
-<div class="flow">parent AI -> private roost MCP -> agents on the roost server</div>
+<div class="flow">parent AI -> private roost HTTP MCP -> embedded wing -> agents</div>
 <div class="recipe-row"><a href="/patterns/shared-roost-agents/INSTRUCTIONS.md">read setup guide</a><button class="copy-recipe" data-copy="/patterns/shared-roost-agents/INSTRUCTIONS.md">copy setup guide</button></div>
+</section>
+
+<section class="pattern" data-route="hosted-relay">
+<div class="pattern-num">07</div>
+<div class="pattern-tags"><span class="pattern-tag">remote computer</span><span class="pattern-tag">browser</span><span class="pattern-tag">optional hosted relay</span></div>
+<h2>Use the entitled hosted browser on a remote wing</h2>
+<p>Choose this optional route only when running a self-hosted browser portal is not the desired setup and the account already has hosted-relay access.</p>
+<ul class="pattern-facts">
+<li><strong>You need:</strong> an account with hosted-relay access; a wing running <code>wt login</code> and <code>wt start</code>; and effective wing policy <code>hosted_relay: allow</code>.</li>
+<li><strong>You get:</strong> a hosted browser terminal whose application-encrypted payloads are relayed to the selected wing. The service still sees routing metadata and supplies the browser code.</li>
+</ul>
+<div class="flow">hosted browser -> encrypted relay -> selected wing -> agent</div>
+<div class="recipe-row"><a href="/patterns/hosted-browser-wing/INSTRUCTIONS.md">read setup guide</a><button class="copy-recipe" data-copy="/patterns/hosted-browser-wing/INSTRUCTIONS.md">copy setup guide</button></div>
 </section>
 </div>
 </main>

--- a/patterns/SKILL.md
+++ b/patterns/SKILL.md
@@ -13,6 +13,8 @@ Choose the outcome the user wants. Only offer the supported setups below.
   [local sub-agents](local-subagents/INSTRUCTIONS.md).
 - Let one AI manage agents on several computers: read
   [remote orchestration](remote-orchestration/INSTRUCTIONS.md).
+- Use the hosted browser with a relay-entitled account and an allowing wing: read
+  [hosted browser wing](hosted-browser-wing/INSTRUCTIONS.md).
 - Control a remote agent from a localhost browser through a self-hosted portal and
   SSH tunnel: read
   [personal remote wing](personal-remote-wing/INSTRUCTIONS.md).

--- a/patterns/SKILL.md
+++ b/patterns/SKILL.md
@@ -1,27 +1,28 @@
 ---
 name: patterns
-description: Set up a supported Wingthing workflow for local agents, remote machines, or a private shared roost.
+description: Choose the smallest supported local-first Wingthing route for an agent or person, then add remote or browser access only when required.
 ---
 
 # Wingthing patterns
 
-Choose the outcome the user wants. Only offer the supported setups below.
+Choose the first supported route that satisfies the request:
 
-- Run a durable sandboxed agent on this computer: read
-  [local sandbox](local-sandbox/INSTRUCTIONS.md).
-- Let the current Claude or Codex session launch local sub-agents: read
-  [local sub-agents](local-subagents/INSTRUCTIONS.md).
-- Let one AI manage agents on several computers: read
-  [remote orchestration](remote-orchestration/INSTRUCTIONS.md).
-- Use the hosted browser with a relay-entitled account and an allowing wing: read
-  [hosted browser wing](hosted-browser-wing/INSTRUCTIONS.md).
-- Control a remote agent from a localhost browser through a self-hosted portal and
-  SSH tunnel: read
-  [personal remote wing](personal-remote-wing/INSTRUCTIONS.md).
-- Give a team a private browser-based agent host: read
-  [shared web roost](shared-web-roost/INSTRUCTIONS.md).
-- Let an AI control agents on a private roost: read
-  [shared roost agents](shared-roost-agents/INSTRUCTIONS.md).
+1. **Local agent control with stdio MCP:** let the current Claude or Codex
+   session manage local sub-agents on existing code and provider logins. Read
+   [local sub-agents](local-subagents/INSTRUCTIONS.md).
+2. **Local sandboxed agent terminal for a person:** run and later reattach to an
+   agent on this computer. Read [local sandbox](local-sandbox/INSTRUCTIONS.md).
+3. **Direct remote MCP when machines differ:** let one AI explicitly select and
+   manage agents on several computers. Read
+   [remote orchestration](remote-orchestration/INSTRUCTIONS.md).
+4. **Self-hosted roost when a person needs a browser:** for one person's remote
+   machine, read [personal remote wing](personal-remote-wing/INSTRUCTIONS.md). For
+   a team browser host, read [shared web roost](shared-web-roost/INSTRUCTIONS.md).
+   To connect an AI to that private roost, read
+   [shared roost agents](shared-roost-agents/INSTRUCTIONS.md).
+5. **Optional entitled hosted relay:** only when the account already has
+   hosted-relay access and the selected wing allows it, read
+   [hosted browser wing](hosted-browser-wing/INSTRUCTIONS.md).
 
 Do not present planned features as patterns. In particular, Wingthing does not
 currently merge independent roosts into one inventory, provide browser-direct free

--- a/patterns/hosted-browser-wing/INSTRUCTIONS.md
+++ b/patterns/hosted-browser-wing/INSTRUCTIONS.md
@@ -1,0 +1,79 @@
+# Use the hosted browser on a remote wing
+
+Use this setup when a person wants to start or resume a persistent agent terminal
+from `app.wingthing.ai` and the account already has hosted-relay access. This is a
+different transport from free native MCP and from a self-hosted roost:
+
+```text
+hosted browser -> application-encrypted relay -> selected wing -> Claude or Codex
+```
+
+Native `wt mcp connect` sends MCP payloads directly to a wing and never falls back
+to this relay. A self-hosted roost supplies its own browser and relay without a
+wingthing.ai relay entitlement.
+
+## Placement and durable state
+
+| Decision | This setup |
+| --- | --- |
+| **Driver** | A person using the hosted browser. |
+| **Execution wing** | The wing explicitly selected in the browser. The hosted service routes control but does not run the agent. |
+| **Workspace** | An existing allowed directory on the selected wing. Wingthing does not clone, upload, or synchronize it. |
+| **Display** | A persistent browser terminal relayed between the browser and wing. The same session remains attachable with `wt attach` on the execution wing. |
+| **Provider credentials** | The execution owner's provider-agent home on the wing. Authenticate the provider CLI on that machine before using the browser. |
+| **Durable memory** | Session, task, provider-history, and optional Wingthing memory remain on the execution wing. The hosted gateway retains account, routing, entitlement, and other gateway metadata, not terminal bytes. |
+
+## 1. Check both relay decisions
+
+The hosted gateway must report relay access for the signed-in account. The public
+`direct-free` deployment does not give new free accounts browser-relay access or
+provide a self-service switch for granting it.
+
+The wing must also allow hosted relay. An omitted `hosted_relay` setting has the
+compatible effective value `allow`. If the wing was intentionally made direct-only,
+do not weaken that policy without the operator's approval. To inspect it:
+
+```sh
+wt wing config
+```
+
+If the operator chooses to re-enable hosted relay, the change requires a restart:
+
+```sh
+wt wing config set hosted_relay=allow
+wt stop
+wt start
+```
+
+Account access and wing policy are independent. `hosted_relay: deny` wins even for
+an entitled account.
+
+## 2. Prepare the execution wing
+
+On the computer that will run the agent, install Wingthing and the provider CLI,
+authenticate the provider as the OS user who will own the work, and make sure the
+project already exists under one of the wing's configured paths. Then connect the
+wing to the hosted account:
+
+```sh
+curl -fsSL https://wingthing.ai/install.sh | sh
+wt login
+wt start
+wt wing status
+```
+
+## 3. Start or resume the terminal
+
+Open `https://app.wingthing.ai`, choose the online wing and an existing allowed
+project directory, then choose the installed agent. The browser starts a persistent
+PTY on that wing. Closing the browser detaches from the terminal; it does not stop
+the process.
+
+## Security boundary
+
+Terminal payloads are application-encrypted between the browser and wing during
+normal operation. The hosted service routes ciphertext but still sees account,
+wing, session, selected-agent, working-directory, timing, and size metadata. It also
+serves the browser client, so transport encryption does not remove the need to trust
+that delivered code or its initial key handling. Provider credentials, project
+files, task state, and terminal content remain on the wing.

--- a/patterns/hosted-browser-wing/INSTRUCTIONS.md
+++ b/patterns/hosted-browser-wing/INSTRUCTIONS.md
@@ -1,8 +1,9 @@
 # Use the hosted browser on a remote wing
 
-Use this setup when a person wants to start or resume a persistent agent terminal
-from `app.wingthing.ai` and the account already has hosted-relay access. This is a
-different transport from free native MCP and from a self-hosted roost:
+Use this optional route only when a person wants a hosted browser, the account
+already has hosted-relay access, and the selected wing allows hosted relay. Prefer
+a self-hosted roost when the person can run the browser portal. This is a different
+transport from direct native MCP and from a self-hosted roost:
 
 ```text
 hosted browser -> application-encrypted relay -> selected wing -> Claude or Codex

--- a/patterns/local-sandbox/INSTRUCTIONS.md
+++ b/patterns/local-sandbox/INSTRUCTIONS.md
@@ -1,7 +1,9 @@
 # Run a durable, sandboxed agent terminal on this computer
 
-Use this setup when you want to run Claude, Codex, or another agent in a local
-project. No Wingthing account or server is required.
+Use this setup when a person wants a local sandboxed Claude, Codex, or other agent
+terminal. If an existing parent agent should drive the work instead, use the
+[local stdio MCP setup](../local-subagents/INSTRUCTIONS.md). No Wingthing account
+or server is required.
 
 Wingthing applies the project's sandbox policy and keeps the terminal alive if you
 close the window or lose the connection.

--- a/patterns/local-subagents/INSTRUCTIONS.md
+++ b/patterns/local-subagents/INSTRUCTIONS.md
@@ -1,8 +1,10 @@
 # Let your current AI launch local sub-agents
 
-Use this setup when a parent Claude or Codex session should delegate work to other
-agents on the same computer. Wingthing gives the parent typed tools to start, wait
-for, inspect, steer, and stop those child agents.
+Start here when a parent Claude or Codex session should delegate work to agents on
+the same computer. Local stdio MCP uses the code and provider logins already on
+this machine; it needs no Wingthing account, daemon, roost, or hosted relay.
+Wingthing gives the parent typed tools to start, wait for, inspect, steer, and stop
+those child agents.
 
 ## Placement and durable state
 

--- a/patterns/personal-remote-wing/INSTRUCTIONS.md
+++ b/patterns/personal-remote-wing/INSTRUCTIONS.md
@@ -1,14 +1,16 @@
 # Control a remote agent from a self-hosted browser
 
-Run the Wingthing web app on the computer in front of you, then connect a remote
-computer to it through SSH. Claude or Codex runs on the remote computer; your
-browser stays pointed at `localhost`.
+Choose this route when a person needs browser visibility into an agent on another
+machine. Run the Wingthing web app on the computer in front of you, then connect a
+remote computer to it through SSH. Claude or Codex runs on the remote computer;
+your browser stays pointed at `localhost`.
 
 ```text
 localhost browser -> local portal -> SSH tunnel -> remote wing -> Claude or Codex
 ```
 
-This is the smallest self-hosted setup. It does not use wingthing.ai.
+This is the first browser route to consider and the smallest self-hosted setup. It
+does not use wingthing.ai or require a hosted-relay entitlement.
 
 ## Placement and durable state
 

--- a/patterns/remote-orchestration/INSTRUCTIONS.md
+++ b/patterns/remote-orchestration/INSTRUCTIONS.md
@@ -1,7 +1,8 @@
 # Let one AI manage agents on several computers
 
-Use this setup when one parent Claude or Codex session should run durable agents on
-several machines—for example, a home computer and an office VM.
+Use this setup only when the parent agent and execution wing are on different
+machines—for example, a home computer and an office VM. On one machine, prefer
+local `wt mcp stdio`.
 
 After setup, the parent AI can:
 
@@ -11,9 +12,9 @@ After setup, the parent AI can:
 - reconnect to work that kept running after the parent disconnected.
 
 Agent-control payloads travel over a direct encrypted connection to the selected
-computer. `wingthing.ai` handles login, the authorized computer list, and connection
-setup; it does not proxy free-tier MCP payloads. No execution computer needs an
-inbound port.
+computer. `wingthing.ai` handles login, the authorized computer list, and
+connection setup; it does not proxy direct MCP payloads or silently switch the
+connector to hosted relay. No execution computer needs an inbound port.
 
 ## Placement and durable state
 
@@ -45,7 +46,8 @@ already exist on the computer where they will run.
 ## 2. Connect the parent AI
 
 On the computer where you run the parent Claude or Codex session, install Wingthing
-and log into the same account. Then add the native connector.
+and log in using an account authorized for the execution wings, personally or
+through organization membership. Then add the native connector.
 
 Codex:
 

--- a/patterns/shared-roost-agents/INSTRUCTIONS.md
+++ b/patterns/shared-roost-agents/INSTRUCTIONS.md
@@ -1,8 +1,10 @@
 # Let an AI control agents on your private roost
 
 Use this setup when a local Claude or Codex session should manage agents on your
-self-hosted Wingthing server. Workspaces, child-agent credentials, and processes stay
-on the roost server.
+self-hosted Wingthing server through its authenticated HTTP MCP endpoint. Use local
+stdio MCP instead when parent and child agents run on the same computer; use direct
+remote MCP when selecting among several external wings. Workspaces, child-agent
+credentials, and processes stay on the roost server.
 
 ## Placement and durable state
 

--- a/patterns/shared-web-roost/INSTRUCTIONS.md
+++ b/patterns/shared-web-roost/INSTRUCTIONS.md
@@ -1,8 +1,9 @@
 # Give a team a private browser-based agent host
 
-Use this setup when several people should run agents on one shared server through a
-private web UI. A **roost** is Wingthing's self-hosted portal, gateway, and agent
-runtime in one service.
+Use this self-hosted browser setup when several people should run agents on one
+shared server through a private web UI. A **roost** is Wingthing's portal, gateway,
+and agent runtime in one service; it does not require a wingthing.ai hosted-relay
+entitlement.
 
 Each signed-in person gets their own sessions and provider-agent home. Project files
 and all agent processes remain on the shared server.

--- a/test/web/README.md
+++ b/test/web/README.md
@@ -45,3 +45,7 @@ terminal open/detach/reattach/end lifecycle, and the no-enrollment-allowlist
 backward-compatibility contract. It records the one terminal ID it creates in
 `deployed-org-results.json`, allowing the operator to clean up precisely after
 an interrupted run. It does not create or modify database records itself.
+
+CI normally uses Playwright's bundled Chromium. A live operator can set
+`WT_E2E_CHROMIUM_EXECUTABLE` to an installed Chrome or Chromium executable to
+avoid downloading a browser.

--- a/test/web/deployed-org.mjs
+++ b/test/web/deployed-org.mjs
@@ -129,7 +129,14 @@ async function apiIdentity(principalState, who) {
 }
 
 fs.mkdirSync(OUT, { recursive: true });
-const browser = await chromium.launch({ args: ['--disable-dev-shm-usage', '--no-sandbox'] });
+const launchOptions = { args: ['--disable-dev-shm-usage', '--no-sandbox'] };
+// CI uses Playwright's bundled Chromium. Operators can point the live canary at
+// an already-installed Chromium-family browser instead of downloading another
+// browser solely to exercise a deployed roost.
+if (process.env.WT_E2E_CHROMIUM_EXECUTABLE) {
+  launchOptions.executablePath = process.env.WT_E2E_CHROMIUM_EXECUTABLE;
+}
+const browser = await chromium.launch(launchOptions);
 const openContexts = [];
 
 try {

--- a/test/web/direct-only.mjs
+++ b/test/web/direct-only.mjs
@@ -24,6 +24,49 @@ async function contextFor(browser, token) {
 const browser = await chromium.launch({ args: ['--disable-dev-shm-usage', '--no-sandbox'] });
 fs.mkdirSync(OUT, { recursive: true });
 try {
+  const publicContext = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    deviceScaleFactor: 2,
+  });
+  const publicPage = await publicContext.newPage();
+  await publicPage.goto(BASE + '/', { waitUntil: 'domcontentloaded' });
+  const publicState = await publicPage.evaluate(() => {
+    const nav = document.querySelector('nav.site-nav');
+    const logo = nav.querySelector('.logo').getBoundingClientRect();
+    const links = nav.querySelector('.nav-links');
+    const linkElements = Array.from(links.querySelectorAll('a'));
+    const linkRects = linkElements.map((link) => link.getBoundingClientRect());
+    const routeElements = Array.from(document.querySelectorAll('.route-map [data-route]'));
+    const selfHosted = routeElements.find((route) => route.dataset.route === 'self-hosted-browser');
+    return {
+      navLabels: linkElements.map((link) => link.textContent.trim()),
+      ctaLabels: linkElements.filter((link) => link.classList.contains('nav-cta')).map((link) => link.textContent.trim()),
+      flexWrap: getComputedStyle(links).flexWrap,
+      linksBelowLogo: links.getBoundingClientRect().top >= logo.bottom,
+      linksInsideViewport: linkRects.every((rect) => rect.width > 0 && rect.left >= 0 && rect.right <= innerWidth + 0.5),
+      noHorizontalOverflow: document.documentElement.scrollWidth <= innerWidth,
+      routes: routeElements.map((route) => route.dataset.route),
+      selfHostedHref: selfHosted ? selfHosted.getAttribute('href') : '',
+      selfHostedText: selfHosted ? selfHosted.textContent : '',
+    };
+  });
+  record('public mobile: nav wraps below the logo without clipping and keeps neutral actions',
+    JSON.stringify(publicState.navLabels) === JSON.stringify(['patterns', 'docs', 'github', 'install locally', 'login']) &&
+      JSON.stringify(publicState.ctaLabels) === JSON.stringify(['install locally']) &&
+      publicState.flexWrap === 'wrap' && publicState.linksBelowLogo &&
+      publicState.linksInsideViewport && publicState.noHorizontalOverflow,
+    JSON.stringify(publicState));
+  record('public mobile: home renders the required hierarchy with a coherent self-hosted recipe',
+    JSON.stringify(publicState.routes) === JSON.stringify([
+      'local-agent', 'local-human', 'direct-remote', 'self-hosted-browser', 'hosted-relay',
+    ]) &&
+      publicState.selfHostedHref === '/patterns/personal-remote-wing/INSTRUCTIONS.md' &&
+      publicState.selfHostedText.includes('wt serve --local --https') &&
+      !publicState.selfHostedText.includes('wt roost start --https'),
+    JSON.stringify(publicState));
+  await publicPage.screenshot({ path: `${OUT}/public-mobile-nav.png`, fullPage: false });
+  await publicContext.close();
+
   const direct = await contextFor(browser, TOKENS.direct);
   await direct.addInitScript(function() {
     // Context init scripts also run in the opaque-origin preview iframe. Seed


### PR DESCRIPTION
Sol-authored docs and implementation fixes from the deployment audit. Includes canonical sandbox-preview policy rendering, Fly edge role detection before state initialization, an explicit hosted-browser pattern, and regression/contract coverage.